### PR TITLE
Implemented missing support for DNSMASQ_LISTENING environment variable

### DIFF
--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -120,6 +120,14 @@ setup_dnsmasq_interface() {
     [ -n "$interface" ] && change_setting "PIHOLE_INTERFACE" "${interface}"
 }
 
+setup_dnsmasq_listening_behaviour() {
+    local dnsmasq_listening_behaviour="${1}"
+
+    if [ -n "$dnsmasq_listening_behaviour" ]; then
+      change_setting "DNSMASQ_LISTENING" "${dnsmasq_listening_behaviour}"
+    fi;
+}
+
 setup_dnsmasq_config_if_missing() {
     # When fresh empty directory volumes are used we miss this file
     if [ ! -f /etc/dnsmasq.d/01-pihole.conf ] ; then
@@ -131,10 +139,12 @@ setup_dnsmasq() {
     local dns1="$1"
     local dns2="$2"
     local interface="$3"
+    local dnsmasq_listening_behaviour="$4"
     # Coordinates 
     setup_dnsmasq_config_if_missing
     setup_dnsmasq_dns "$dns1" "$dns2" 
     setup_dnsmasq_interface "$interface"
+    setup_dnsmasq_listening_behaviour "$dnsmasq_listening_behaviour"
     ProcessDNSSettings
 }
 

--- a/start.sh
+++ b/start.sh
@@ -11,6 +11,7 @@ export WEBLOGDIR
 export DNS1
 export DNS2
 export INTERFACE
+export DNSMASQ_LISTENING_BEHAVIOUR="$DNSMASQ_LISTENING"
 export IPv6
 export WEB_PORT
 
@@ -32,7 +33,7 @@ change_setting "IPV4_ADDRESS" "$ServerIP"
 change_setting "IPV6_ADDRESS" "$ServerIPv6"
 setup_web_port "$WEB_PORT"
 setup_web_password "$WEBPASSWORD"
-setup_dnsmasq "$DNS1" "$DNS2" "$INTERFACE"
+setup_dnsmasq "$DNS1" "$DNS2" "$INTERFACE" "$DNSMASQ_LISTENING_BEHAVIOUR"
 setup_php_env
 setup_dnsmasq_hostnames "$ServerIP" "$ServerIPv6" "$HOSTNAME"
 setup_ipv4_ipv6


### PR DESCRIPTION
Documentation included reference to a "DNSMASQ_LISTENING" environment variable which could be supplied to the docker container to change the DNSMASQ listening behaviour, this was not implemented in the start script so had not effect. This change implements updating the setupVars configuration file based on the environment variable value. 

## Description
Change to the setup_dnsmasq function in bash_functions to take an additional parameter for the DNSMASQ_LISTENING environment variable value. If this is a non-empty string the DNSMASQ_LISTENING setting will be written to the setupVars.conf configuration file. 

## Motivation and Context
Fixes feature noted in the documentation which is missing. 

## How Has This Been Tested?
Manual testing has been performed against the amd_64 version of the image (changes are version agnostic), checking that the environment variable values of "all" and "local" make the appropriate change to the settings displayed in the "DNS" tab of the admin web interface. Confirmed no environment variable supplied functions as before. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.