### PR TITLE
Update doco-example.yml with dns flags

### DIFF
--- a/doco-example.yml
+++ b/doco-example.yml
@@ -2,6 +2,9 @@ version: "3"
 services:
   pihole:
     image: pihole/pihole:latest
+    dns:
+      - 127.0.0.1
+      - 1.1.1.1
     ports:
       - "53:53/tcp"
       - "53:53/udp"


### PR DESCRIPTION
I had the following issue when I used docker-compose to start docker pi-hole:
```
[✗] DNS resolution is currently unavailable
```
This PR change helped me resolve that issue when I discovered the solution at https://discourse.pi-hole.net/t/issues-with-docker-pihole/12304/5