### PR TITLE
IPRoute v3 ip lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A [Docker](https://www.docker.com/what-docker) project to make a lightweight x86
 This container uses 2 popular ports, port 53 and port 80, so **may conflict with existing applications ports**.  If you have no other services or docker containers using port 53/80 (if you do, keep reading below for a reverse proxy example), the minimum arguments required to run this container are in the script [docker_run.sh](https://github.com/pi-hole/docker-pi-hole/blob/master/docker_run.sh) or summarized here:
 
 ```bash
-IP_LOOKUP="$(ip route get 8.8.8.8 | awk '{ print $NF; exit }')"  # May not work for VPN / tun0
+IP_LOOKUP="$(ip route get 8.8.8.8 | awk '{for(i=1;i<=NF;i++) if ($i=="src") print $(i+1)}')"  # May not work for VPN / tun0
 IPv6_LOOKUP="$(ip -6 route get 2001:4860:4860::8888 | awk '{for(i=1;i<=NF;i++) if ($i=="src") print $(i+1)}')"  # May not work for VPN / tun0
 IP="${IP:-$IP_LOOKUP}"  # use $IP, if set, otherwise IP_LOOKUP
 IPv6="${IPv6:-$IPv6_LOOKUP}"  # use $IPv6, if set, otherwise IP_LOOKUP

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Lookups may not work for VPN / tun0
-IP_LOOKUP="$(ip route get 8.8.8.8 | awk '{ print $NF; exit }')"  
+IP_LOOKUP="$(ip route get 8.8.8.8 | awk '{for(i=1;i<=NF;i++) if ($i=="src") print $(i+1)}')"  
 IPv6_LOOKUP="$(ip -6 route get 2001:4860:4860::8888 | awk '{for(i=1;i<=NF;i++) if ($i=="src") print $(i+1)}')"  
 
 # Just hard code these to your docker server's LAN IP if lookups aren't working


### PR DESCRIPTION
New iproute version has new column ordering. 

The IP is always after 'src' regardles of version, so the best logic is iterating through columns and using 1 after 'src'.

Fixes #346
Fixes #312

(misnamed branch name, version of awk has nothing to do with this)