### PR TITLE
Tidy up docker run script

### DIFF
--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 # Lookups may not work for VPN / tun0
 IP_LOOKUP="$(ip route get 8.8.8.8 | awk '{for(i=1;i<=NF;i++) if ($i=="src") print $(i+1)}')"
 IPv6_LOOKUP="$(ip -6 route get 2001:4860:4860::8888 | awk '{for(i=1;i<=NF;i++) if ($i=="src") print $(i+1)}')"

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 # Lookups may not work for VPN / tun0
-IP_LOOKUP="$(ip route get 8.8.8.8 | awk '{for(i=1;i<=NF;i++) if ($i=="src") print $(i+1)}')"  
-IPv6_LOOKUP="$(ip -6 route get 2001:4860:4860::8888 | awk '{for(i=1;i<=NF;i++) if ($i=="src") print $(i+1)}')"  
+IP_LOOKUP="$(ip route get 8.8.8.8 | awk '{for(i=1;i<=NF;i++) if ($i=="src") print $(i+1)}')"
+IPv6_LOOKUP="$(ip -6 route get 2001:4860:4860::8888 | awk '{for(i=1;i<=NF;i++) if ($i=="src") print $(i+1)}')"
 
 # Just hard code these to your docker server's LAN IP if lookups aren't working
 IP="${IP:-$IP_LOOKUP}"  # use $IP, if set, otherwise IP_LOOKUP
 IPv6="${IPv6:-$IPv6_LOOKUP}"  # use $IPv6, if set, otherwise IP_LOOKUP
 
 # Default of directory you run this from, update to where ever.
-DOCKER_CONFIGS="$(pwd)"  
+DOCKER_CONFIGS="$(pwd)"
 
-echo "### Make sure your IPs are correct, hard code ServerIP ENV VARs if necessary\nIP: ${IP}\nIPv6: ${IPv6}"
+echo -e "### Make sure your IPs are correct, hard code ServerIP ENV VARs if necessary\nIP: ${IP}\nIPv6: ${IPv6}"
 
 # Default ports + daemonized docker container
 docker run -d \
@@ -28,5 +28,11 @@ docker run -d \
     --dns=127.0.0.1 --dns=1.1.1.1 \
     pihole/pihole:latest
 
-echo -n "Your password for https://${IP}/admin/ is "
-docker logs pihole 2> /dev/null | grep 'password:'
+
+printf 'Starting up pihole container'
+while [ "$(docker inspect -f "{{.State.Health.Status}}" pihole)" != "healthy" ]; do
+    sleep 1
+    printf '.'
+done;
+
+echo -e "\n$(docker logs pihole 2> /dev/null | grep 'password:') for your pi-hole: https://${IP}/admin/"


### PR DESCRIPTION
Cleanup trailing white-space, More considerate output for beginners and general cleanup around bash best practices. Plus we ensure the password is outputted for user. By default currently it's not and the user has to run the command manually again. 

## Description
The following does some general cleanup such as removing whitespace and ensuring bash best practices.  Most importantly though it Adds a wait so the container has some time to start up. When done the user will get the password they set, even if they hardcoded it into their script. 

The output will show the container is still starting with successive dots being printed until a container is marked as healthy. 

## Motivation and Context
Upon setting up pi-hole for myself I felt this script could have been easier to use for a beginner. I found myself having to dig for the random password

## How Has This Been Tested?
Use it myself. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


If you have any concerns let me know. 