### PR TITLE
Extend sleep and add env file for usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__
 .tox
 .eggs
 UNKNOWN.egg-info
+.env
 
 # WIP/test stuff
 doco.yml

--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ Here is a rundown of the other arguments passed into the example `docker run`:
 
 | Docker Arguments | Description |
 | ---------------- | ----------- |
-| `--env-file .env` <br/> *Optional* | File to store environment variables for docker. Here for convenience
 | `-p 80:80`<br/>`-p 53:53/tcp -p 53:53/udp`<br/> **Recommended** | Ports to expose, the bare minimum ports required for Pi-holes HTTP and DNS services
 | `--restart=unless-stopped`<br/> **Recommended** | Automatically (re)start your Pi-hole on boot or in the event of a crash
 | `-v /dir/for/pihole:/etc/pihole`<br/> **Recommended** | Volumes for your Pi-hole configs help persist changes across docker image updates
@@ -125,7 +124,7 @@ Here is a rundown of the other arguments passed into the example `docker run`:
 | `--cap-add=NET_ADMIN`<br/> *Required* | FTL DNS will fail to start without this setting
 | `--dns=127.0.0.1`<br/> *Recommended* | Sets your container's resolve settings to localhost so it can resolve DHCP hostnames from Pi-hole's DNSMasq <!-- also fixes common resolution errors on container restart -->
 | `--dns=1.1.1.1`<br/> *Optional* | Sets a backup server of your choosing in case DNSMasq has problems starting
-
+| `--env-file .env` <br/> *Optional* | File to store environment variables for docker. Here for convenience
 If you're a fan of [docker-compose](https://docs.docker.com/compose/install/) I have [example docker-compose.yml files](https://github.com/pi-hole/docker-pi-hole/blob/master/doco-example.yml) in github which I think are a nicer way to represent such long run commands.
 
 ## Tips and Tricks

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -13,8 +13,10 @@ DOCKER_CONFIGS="$(pwd)"
 echo -e "### Make sure your IPs are correct, hard code ServerIP ENV VARs if necessary\nIP: ${IP}\nIPv6: ${IPv6}"
 
 # Default ports + daemonized docker container
+# Environment variables for docker can be defined in --env-file (.env)
 docker run -d \
     --name pihole \
+    --env-file .env \
     -p 53:53/tcp -p 53:53/udp \
     -p 80:80 \
     -p 443:443 \
@@ -28,19 +30,19 @@ docker run -d \
     pihole/pihole:latest
 
 
-printf 'Starting up pihole container'
+printf 'Starting up pihole container '
 for i in $(seq 1 20); do
     if [ "$(docker inspect -f "{{.State.Health.Status}}" pihole)" == "healthy" ] ; then
         printf ' OK'
-        break
+        echo -e "\n$(docker logs pihole 2> /dev/null | grep 'password:') for your pi-hole: https://${IP}/admin/"
+        exit 0
     else
-        sleep 1
+        sleep 3
         printf '.'
     fi
 
     if [ $i -eq 20 ] ; then
         echo -e "\nTimed out waiting for Pi-hole start start, consult check your container logs for more info (\`docker logs pihole\`)"
+        exit 1
     fi
 done;
-
-echo -e "\n$(docker logs pihole 2> /dev/null | grep 'password:') for your pi-hole: https://${IP}/admin/"

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -13,7 +13,7 @@ DOCKER_CONFIGS="$(pwd)"
 echo -e "### Make sure your IPs are correct, hard code ServerIP ENV VARs if necessary\nIP: ${IP}\nIPv6: ${IPv6}"
 
 # Default ports + daemonized docker container
-# Environment variables for docker can be defined in --env-file (.env)
+# Environment variables for docker can be defined in --env-file .env file
 docker run -d \
     --name pihole \
     --env-file .env \


### PR DESCRIPTION
The previous changes we made were a nice step forward. But I found that with the 1 second sleep we could fail but still succeed if that makes sense. We would hit 20 iterations but it would all still work and tell the user it failed. This extends the sleep to 3 seconds and adds use of the .env file. We also update the Readme. 

## Description
Pretty much the same as above. Though I updated the Readme which was forgotten last time. The env file is a nice addition I think. Some companies and people (like myself) will want to set passwords or use their automation to template the .env file. One major positive for the .env file is for us to safely dev in the same branch we run out of. Not defining WEBPASSWORD certainly does that but it is nice to have a consistent personal password so you can access pihole from a phone for example to whitelist a site. We also add the .env file to the .gitignore so it's not accidentally committed. 

## Motivation and Context
Upon testing our last collaboration I noticed that 20 seconds of sleep was close to adequate but occasionally on my rasp pi 3 b+ i hit 20 seconds. Given that I moved the sleep to 3 seconds per iteration. This averages around 10 for me in testing which is pretty good as a mid point. 

## How Has This Been Tested?
I am testing in my home and things seem Great

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

Thanks. Happy to make any changes you suggest. :)
