### PR TITLE
Update with 4.1.1+ requirement for cap_add

### DIFF
--- a/doco-example.yml
+++ b/doco-example.yml
@@ -10,9 +10,9 @@ services:
       - "53:53/udp"
       - "80:80/tcp"
       - "443:443/tcp"
-    # The 3 lines below are required if Pi-hole is to provide DHCP
-    # cap_add:
-    #  - NET_ADMIN
+    cap_add:
+      - NET_ADMIN
+    # required if Pi-hole is to provide DHCP
     # network_mode: "host"
     environment:
       # enter your docker host IP here


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Uncommented the line including cap_add, as it's suggested/required in 4.1.1+ to start DNS service, not just for DHCP. Moved the latter portion of the description lower.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This previously optional argument is now required or strongly encouraged as per the README, so I suggest it be included by default in the example compose. Additionally, it may be worthwhile to highlight in the documentation somewhere that the argument cap-add is cap_add in compose. Caused me a bit of (inexperienced) headache.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
