### PR TITLE
Enhance systemd support and document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,9 +187,9 @@ Similarly for the webserver you can customize configs in /etc/lighttpd
 
 ### Systemd init script
 
-As long as your docker system service auto starts on boot and you run your container with `--restart=unless-stopped` your container should always start on boot and restart on crashes.  If you prefer to have your docker container run as a systemd service instead, add the file [pihole.service](https://raw.githubusercontent.com/pi-hole/docker-pi-hole/master/pihole.service) to "/etc/systemd/system"; customize whatever your container name is and remove `--restart=unless-stopped` from your docker run.  Then after you have initially created the docker container using the docker run command above, you can control it with "systemctl start pihole" or "systemctl stop pihole" (instead of `docker start`/`docker stop`).  You can also enable it to auto-start on boot with "systemctl enable pihole" (as opposed to `--restart=unless-stopped` and making sure docker service auto-starts on boot).
+As long as your docker system service auto starts on boot and you run your container with `--restart=unless-stopped` your container should always start on boot and restart on crashes.  If you prefer to have your docker container run as a systemd service instead, add the file [pihole.service](https://raw.githubusercontent.com/pi-hole/docker-pi-hole/master/pihole.service) to "/etc/systemd/system"; customize with volumes for /etc/pihole and /etc/dnsmasq.d as well as any other advanced options noted above. You can now control pihole with "systemctl start pihole" or "systemctl stop pihole".  To enable auto-starting on boot use "systemctl enable pihole".
 
-NOTE:  After initial run you may need to manually stop the docker container with "docker stop pihole" before the systemctl can start controlling the container.
+NOTE:  If you had been using "docker run" manually before you may need to manually stop the docker container with "docker stop pihole" before the systemctl can start controlling the container.
 
 ## Note on Capabilities
 

--- a/pihole.service
+++ b/pihole.service
@@ -5,9 +5,12 @@ After=docker.service network-online.target dhcpd.service
 
 [Service]
 Restart=always
-ExecStart=/usr/bin/docker start -a pihole
-ExecStop=/usr/bin/docker stop -t 2 pihole
+# Make sure to add volumes for both /etc/pihole and /etc/dnsmasq.d
+ExecStart=/usr/bin/docker run --rm --name %N \
+		--net host --cap-add=NET_ADMIN \
+		--dns 127.0.0.1 --dns 8.8.8.8 \
+		pihole/pihole:latest
+ExecStop=/usr/bin/docker stop -t 2 %N
 
 [Install]
 WantedBy=multi-user.target
-


### PR DESCRIPTION
## Description
- Since we encourage throw-away containers, document having the systemd unit operate in that manner.

## Motivation and Context
The README discourages the use of long-living containers, switching the systemd unit to one that removes itself on exit moves in that direction.

## How Has This Been Tested?
This unit, when based on current master is something (with a few more advanced options passed in too) for some time.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.