### PR TITLE
docker-compose cleanup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,29 +4,29 @@ version: "3"
 
 services:
   pihole:
-    container_name: pihole
     image: pihole/pihole:latest
     # For DHCP it is recommended to remove these ports and instead add: network_mode: "host"
     ports:
+      - "443:443/tcp"
       - "53:53/tcp"
       - "53:53/udp"
       - "67:67/udp"
       - "80:80/tcp"
-      - "443:443/tcp"
     environment:
-      TZ: 'America/Chicago'
-      # WEBPASSWORD: 'set a secure password here or it will be random'
-    # Volumes store your data between container upgrades
+      WEBPASSWORD: ${PASSWORD}
     volumes:
-       - './etc-pihole/:/etc/pihole/'
-       - './etc-dnsmasq.d/:/etc/dnsmasq.d/'
-    # run `touch ./var-log/pihole.log` first unless you like errors
-    # - './var-log/pihole.log:/var/log/pihole.log'
+       - dnsmasq:/etc/dnsmasq.d/
+       - pihole:/etc/pihole/
     dns:
       - 127.0.0.1
       - 1.1.1.1
     # Recommended but not required (DHCP needs NET_ADMIN)
-    #   https://github.com/pi-hole/docker-pi-hole#note-on-capabilities
+    # https://github.com/pi-hole/docker-pi-hole#note-on-capabilities
     cap_add:
       - NET_ADMIN
     restart: unless-stopped
+
+volumes:
+  dnsmasq:
+  pihole:
+


### PR DESCRIPTION
If you guys are fine with these changes - later on I will submit commit a which fixes documentation

## Description
1. Removed `container_name` attribute since it literally does nothing in this case
2. Removed `TZ` attribute since this makes this docker-compose file location-specific. Usually, timezone automagically is set to the same one as host machine
3. Uncommented `WEBPASSWORD` environment variable, this way it is not set to anything unless a person has an environment variable set, this makes this file more flexible
4. Added "named volumes", this way pihole will store its data to the same location as all other dockers containers. This is a breaking change, it is not compatible with older versions of this file

## Motivation and Context
I am in the process of building a new home server and noticed that this file was quite nasty, so here we are...

## How Has This Been Tested?
Tested with `docker-compose` and `docker stack`, both seem to work just fine

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
