### PR TITLE
Add support for additional env var config

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ There are other environment variables if you want to customize various things in
 | `WEBPASSWORD: <Admin password>`<br/> **Recommended** *Default: random* | http://pi.hole/admin password. Run `docker logs pihole \| grep random` to find your random pass.
 | `DNS1: <IP>`<br/> *Optional* *Default: 8.8.8.8* | Primary upstream DNS provider, default is google DNS
 | `DNS2: <IP>`<br/> *Optional* *Default: 8.8.4.4* | Secondary upstream DNS provider, default is google DNS, `no` if only one DNS should used
+| `DNSSEC: <True\|False>`<br/> *Optional* *Default: false* | Enable DNSSEC support
+| `DNS_BOGUS_PRIV: <True\|False>`<br/> *Optional* *Default: true* | Enable forwarding of reverse lookups for private ranges
+| `CONDITIONAL_FORWARDING: <True\|False>`<br/> *Optional* *Default: False* | Enable DNS conditional forwarding for device name resolution
+| `CONDITIONAL_FORWARDING_IP: <Router's IP>`<br/> *Optional* | If conditional forwarding is enabled, set the IP of the local network router
+| `CONDITIONAL_FORWARDING_DOMAIN: <Network Domain>`<br/> *Optional* | If conditional forwarding is enabled, set the domain of the local network router
+| `CONDITIONAL_FORWARDING_REVERSE: <Reverse DNS>`<br/> *Optional* | If conditional forwarding is enabled, set the reverse DNS of the local network router (e.g. `0.168.192.in-addr.arpa`)
 | `ServerIP: <Host's IP>`<br/> **Recommended** | **--net=host mode requires** Set to your server's LAN IP, used by web block modes and lighttpd bind address
 | `ServerIPv6: <Host's IPv6>`<br/> *Required if using IPv6* | **If you have a v6 network** set to your server's LAN IPv6 to block IPv6 ads fully
 | `VIRTUAL_HOST: <Custom Hostname>`<br/> *Optional* *Default: $ServerIP*   | What your web server 'virtual host' is, accessing admin through this Hostname/IP allows you to make changes to the whitelist / blacklists in addition to the default 'http://pi.hole/admin/' address

--- a/start.sh
+++ b/start.sh
@@ -10,10 +10,16 @@ export HOSTNAME
 export WEBLOGDIR
 export DNS1
 export DNS2
+export DNSSEC
+export DNS_BOGUS_PRIV
 export INTERFACE
 export DNSMASQ_LISTENING_BEHAVIOUR="$DNSMASQ_LISTENING"
 export IPv6
 export WEB_PORT
+export CONDITIONAL_FORWARDING
+export CONDITIONAL_FORWARDING_IP
+export CONDITIONAL_FORWARDING_DOMAIN
+export CONDITIONAL_FORWARDING_REVERSE
 
 export adlistFile='/etc/pihole/adlists.list'
 
@@ -40,6 +46,12 @@ validate_env || exit 1
 prepare_configs
 change_setting "IPV4_ADDRESS" "$ServerIP"
 change_setting "IPV6_ADDRESS" "$ServerIPv6"
+change_setting "DNS_BOGUS_PRIV" "$DNS_BOGUS_PRIV"
+change_setting "DNSSEC" "$DNSSEC"
+change_setting "CONDITIONAL_FORWARDING" "$CONDITIONAL_FORWARDING"
+change_setting "CONDITIONAL_FORWARDING_IP" "$CONDITIONAL_FORWARDING_IP"
+change_setting "CONDITIONAL_FORWARDING_DOMAIN" "$CONDITIONAL_FORWARDING_DOMAIN"
+change_setting "CONDITIONAL_FORWARDING_REVERSE" "$CONDITIONAL_FORWARDING_REVERSE"
 setup_web_port "$WEB_PORT"
 setup_web_password "$WEBPASSWORD"
 setup_dnsmasq "$DNS1" "$DNS2" "$INTERFACE" "$DNSMASQ_LISTENING_BEHAVIOUR"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR introduces for configure additional pihole settings via container environment variables, namely:

- `CONDITIONAL_FORWARDING`
- `CONDITIONAL_FORWARDING_DOMAIN`
- `CONDITIONAL_FORWARDING_IP`
- `CONDITIONAL_FORWARDING_REVERSE`
- `DNS_BOGUS_PRIV`
- `DNSSEC`

## Motivation and Context
Immutable containers is the way forward.

## How Has This Been Tested?
I have used a container to test the changes as there already is support for a function which changes settings.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.