### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/Dockerfile.py
+++ b/Dockerfile.py
@@ -15,6 +15,7 @@ Options:
 
 Examples:
 """
+from __future__ import print_function
 
 from docopt import docopt
 from jinja2 import Environment, FileSystemLoader
@@ -64,7 +65,7 @@ images = {
 
 def generate_dockerfiles(args):
     if args['--no-generate']:
-        print " ::: Skipping Dockerfile generation"
+        print(" ::: Skipping Dockerfile generation")
         return
 
     for version, archs in images.iteritems():
@@ -92,13 +93,13 @@ def generate_dockerfiles(args):
 
 def build_dockerfiles(args):
     if args['--no-build']:
-        print " ::: Skipping Dockerfile building"
+        print(" ::: Skipping Dockerfile building")
         return
 
     for arch in args['--arch']:
         # TODO: include from external .py that can be shared with Dockerfile.py / Tests / deploy scripts '''
         if arch == 'armel':
-            print "Skipping armel, incompatible upstream binaries/broken"
+            print("Skipping armel, incompatible upstream binaries/broken")
             continue
         build('pihole', arch, args)
 
@@ -119,16 +120,16 @@ def build(docker_repo, arch, args):
         no_cache = '--no-cache'
     build_command = '{time}docker build {no_cache} --pull --cache-from="{cache},{create_tag}" -f {dockerfile} -t {create_tag} .'\
         .format(time=time, no_cache=no_cache, cache=cached_image, dockerfile=dockerfile, create_tag=repo_tag)
-    print " ::: Building {} into {}".format(dockerfile, repo_tag)
+    print(" ::: Building {} into {}".format(dockerfile, repo_tag))
     if args['-v']:
-        print build_command, '\n'
+        print(build_command, '\n')
     build_result = run_local(build_command) 
     if args['-v']:
-        print build_result.stdout
-        print build_result.stderr
+        print(build_result.stdout)
+        print(build_result.stderr)
     if build_result.rc != 0:
-        print "     ::: Building {} encountered an error".format(dockerfile)
-        print build_result.stderr
+        print("     ::: Building {} encountered an error".format(dockerfile))
+        print(build_result.stderr)
     assert build_result.rc == 0
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import pytest
 import testinfra
 import os
@@ -41,7 +42,7 @@ def DockerGeneric(request, _test_args, _args, _image, _cmd, _entrypoint):
     docker_run = 'docker run -d -t {args} {test_args} {entry} {image} {cmd}'\
         .format(args=_args, test_args=_test_args, entry=_entrypoint, image=_image, cmd=_cmd)
     # Print a human runable version of the container run command for faster debugging
-    print docker_run.replace('-d -t', '--rm -it').replace('tail -f /dev/null', 'bash')
+    print(docker_run.replace('-d -t', '--rm -it').replace('tail -f /dev/null', 'bash'))
     docker_id = check_output(docker_run)
 
     def teardown():

--- a/test/test_bash_functions.py
+++ b/test/test_bash_functions.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import pytest
 import re
@@ -197,5 +198,5 @@ def test_webPassword_pre_existing_trumps_all_envs(Docker, args_env, test_args):
 def test_docker_checks_for_resolvconf_misconfiguration(Docker, args_dns, expected_stdout):
     ''' The container checks for misconfigured resolv.conf '''
     function = Docker.run('. /bash_functions.sh ; eval `grep docker_checks /start.sh`')
-    print function.stdout
+    print(function.stdout)
     assert expected_stdout in function.stdout

--- a/test/test_start.py
+++ b/test/test_start.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import pytest
 import time
 ''' conftest.py provides the defaults through fixtures '''
@@ -44,10 +45,10 @@ def test_indecies_are_present(RunningPiHole):
 
 def validate_curl(http_rc, expected_http_code, page_contents):
     if int(http_rc.rc) != 0 or int(http_rc.stdout) != expected_http_code:
-        print 'CURL return code: {}'.format(http_rc.rc)
-        print 'CURL stdout: {}'.format(http_rc.stdout)
-        print 'CURL stderr:{}'.format(http_rc.stderr)
-        print 'CURL file:\n{}\n'.format(page_contents.encode('utf-8'))
+        print('CURL return code: {}'.format(http_rc.rc))
+        print('CURL stdout: {}'.format(http_rc.stdout))
+        print('CURL stderr:{}'.format(http_rc.stderr))
+        print('CURL file:\n{}\n'.format(page_contents.encode('utf-8')))
 
 
 @pytest.mark.parametrize('addr', [ 'localhost' ] )


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
