### PR TITLE
Build armel image for Pi Zero and Pi gen 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
         - QEMU_VER=v2.9.1
     matrix:
         - ARCH=amd64
+        - ARCH=armel
         - ARCH=armhf
         - ARCH=aarch64
 python:
@@ -16,8 +17,11 @@ install:
 script:
   # prepare qemu
   - docker run --rm --privileged multiarch/qemu-user-static:register --reset
-  # generate and build dockerfile
-  - ./Dockerfile.py --arch=${ARCH} -v
+  # generate dockerfile
+  - ./Dockerfile.py --arch=${ARCH} -v --no-build
+  # run docker build for first stage to prevent Travis timeout
+  - docker build -f Dockerfile_${ARCH} --target build -t pihole:build_${ARCH} .
+  - ./Dockerfile.py --arch=${ARCH} -v --no-generate
   - docker images
   # run docker build & tests
   # 2 parallel max b/c race condition with docker fixture (I think?)

--- a/Dockerfile.py
+++ b/Dockerfile.py
@@ -49,7 +49,8 @@ images = {
         },
         {
             'base': 'multiarch/debian-debootstrap:armel-stretch-slim',
-            'arch': 'armel'
+            'arch': 'armel',
+            'build': True # incompatible upstream binaries
         },
         {
             'base': 'multiarch/debian-debootstrap:armhf-stretch-slim',
@@ -97,9 +98,6 @@ def build_dockerfiles(args):
 
     for arch in args['--arch']:
         # TODO: include from external .py that can be shared with Dockerfile.py / Tests / deploy scripts '''
-        if arch == 'armel':
-            print "Skipping armel, incompatible upstream binaries/broken"
-            continue
         build('pihole', arch, args)
 
 
@@ -111,14 +109,15 @@ def build(docker_repo, arch, args):
     dockerfile = 'Dockerfile_{}'.format(arch)
     repo_tag = '{}:{}_{}'.format(docker_repo, __version__, arch)
     cached_image = '{}/{}'.format('pihole', repo_tag)
+    build_tag = '{}:{}_{}'.format('pihole', 'build', arch)
     time=''
     if args['-t']:
         time='time '
     no_cache = ''
     if args['--no-cache']:
         no_cache = '--no-cache'
-    build_command = '{time}docker build {no_cache} --pull --cache-from="{cache},{create_tag}" -f {dockerfile} -t {create_tag} .'\
-        .format(time=time, no_cache=no_cache, cache=cached_image, dockerfile=dockerfile, create_tag=repo_tag)
+    build_command = '{time}docker build {no_cache} --pull --cache-from="{cache},{create_tag},{build_tag}" -f {dockerfile} -t {create_tag} .'\
+        .format(time=time, no_cache=no_cache, cache=cached_image, dockerfile=dockerfile, create_tag=repo_tag, build_tag=build_tag)
     print " ::: Building {} into {}".format(dockerfile, repo_tag)
     if args['-v']:
         print build_command, '\n'

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,3 +1,16 @@
+FROM multiarch/debian-debootstrap:armel-stretch-slim as build
+WORKDIR /tmp
+
+{% if pihole.build %}
+RUN apt-get update && apt-get install --no-install-recommends -y build-essential libgmp-dev m4 ca-certificates
+RUN wget https://ftp.gnu.org/gnu/nettle/nettle-3.4.tar.gz && tar -xzf nettle-3.4.tar.gz && cd nettle-3.4 && ./configure && \
+    make && make install
+
+RUN wget https://github.com/pi-hole/FTL/archive/{{ pihole.version }}.tar.gz && mkdir -p {{ pihole.version }} && \
+    tar -xzf {{ pihole.version }}.tar.gz -C {{ pihole.version }} --strip-components 1 && cd {{ pihole.version }} && \
+    make
+
+{% endif %}
 FROM {{ pihole.base }}
 
 ENV S6OVERLAY_RELEASE https://github.com/just-containers/s6-overlay/releases/download/{{ pihole.s6_version }}/s6-overlay-{{ pihole.s6arch }}.tar.gz
@@ -18,6 +31,9 @@ ENV PHP_ENV_CONFIG '{{ pihole.php_env_config }}'
 ENV PHP_ERROR_LOG '{{ pihole.php_error_log }}'
 COPY ./start.sh /
 COPY ./bash_functions.sh /
+{% if pihole.build %}
+COPY --from=build /tmp/{{ pihole.version }}/pihole-FTL /tmp/{{ pihole.version }}/dnsmasq /usr/bin/ 
+{% endif %}
 
 # IPv6 disable flag for networks/devices that do not support it
 ENV IPv6 True

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM multiarch/debian-debootstrap:armel-stretch-slim as build
+FROM {{ pihole.base }} as build
 WORKDIR /tmp
 
 {% if pihole.build %}

--- a/Dockerfile_aarch64
+++ b/Dockerfile_aarch64
@@ -1,3 +1,6 @@
+FROM multiarch/debian-debootstrap:armel-stretch-slim as build
+WORKDIR /tmp
+
 FROM multiarch/debian-debootstrap:arm64-stretch-slim
 
 ENV S6OVERLAY_RELEASE https://github.com/just-containers/s6-overlay/releases/download/v1.21.7.0/s6-overlay-aarch64.tar.gz

--- a/Dockerfile_aarch64
+++ b/Dockerfile_aarch64
@@ -1,4 +1,4 @@
-FROM multiarch/debian-debootstrap:armel-stretch-slim as build
+FROM multiarch/debian-debootstrap:arm64-stretch-slim as build
 WORKDIR /tmp
 
 FROM multiarch/debian-debootstrap:arm64-stretch-slim

--- a/Dockerfile_amd64
+++ b/Dockerfile_amd64
@@ -1,3 +1,6 @@
+FROM multiarch/debian-debootstrap:armel-stretch-slim as build
+WORKDIR /tmp
+
 FROM pihole/debian-base:latest
 
 ENV S6OVERLAY_RELEASE https://github.com/just-containers/s6-overlay/releases/download/v1.21.7.0/s6-overlay-amd64.tar.gz

--- a/Dockerfile_amd64
+++ b/Dockerfile_amd64
@@ -1,4 +1,4 @@
-FROM multiarch/debian-debootstrap:armel-stretch-slim as build
+FROM pihole/debian-base:latest as build
 WORKDIR /tmp
 
 FROM pihole/debian-base:latest

--- a/Dockerfile_armel
+++ b/Dockerfile_armel
@@ -1,3 +1,14 @@
+FROM multiarch/debian-debootstrap:armel-stretch-slim as build
+WORKDIR /tmp
+
+RUN apt-get update && apt-get install --no-install-recommends -y build-essential libgmp-dev m4 ca-certificates
+RUN wget https://ftp.gnu.org/gnu/nettle/nettle-3.4.tar.gz && tar -xzf nettle-3.4.tar.gz && cd nettle-3.4 && ./configure && \
+    make && make install
+
+RUN wget https://github.com/pi-hole/FTL/archive/v4.3.1.tar.gz && mkdir -p v4.3.1 && \
+    tar -xzf v4.3.1.tar.gz -C v4.3.1 --strip-components 1 && cd v4.3.1 && \
+    make
+
 FROM multiarch/debian-debootstrap:armel-stretch-slim
 
 ENV S6OVERLAY_RELEASE https://github.com/just-containers/s6-overlay/releases/download/v1.21.7.0/s6-overlay-arm.tar.gz
@@ -18,6 +29,7 @@ ENV PHP_ENV_CONFIG '/etc/lighttpd/conf-enabled/15-fastcgi-php.conf'
 ENV PHP_ERROR_LOG '/var/log/lighttpd/error.log'
 COPY ./start.sh /
 COPY ./bash_functions.sh /
+COPY --from=build /tmp/v4.3.1/pihole-FTL /tmp/v4.3.1/dnsmasq /usr/bin/ 
 
 # IPv6 disable flag for networks/devices that do not support it
 ENV IPv6 True

--- a/Dockerfile_armhf
+++ b/Dockerfile_armhf
@@ -1,4 +1,4 @@
-FROM multiarch/debian-debootstrap:armel-stretch-slim as build
+FROM multiarch/debian-debootstrap:armhf-stretch-slim as build
 WORKDIR /tmp
 
 FROM multiarch/debian-debootstrap:armhf-stretch-slim

--- a/Dockerfile_armhf
+++ b/Dockerfile_armhf
@@ -1,3 +1,6 @@
+FROM multiarch/debian-debootstrap:armel-stretch-slim as build
+WORKDIR /tmp
+
 FROM multiarch/debian-debootstrap:armhf-stretch-slim
 
 ENV S6OVERLAY_RELEASE https://github.com/just-containers/s6-overlay/releases/download/v1.21.7.0/s6-overlay-armhf.tar.gz

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -88,7 +88,7 @@ def DockerPersist(request, persist_test_args, persist_args, persist_image, persi
 def entrypoint():
     return ''
 
-@pytest.fixture(params=['amd64', 'armhf', 'aarch64'])
+@pytest.fixture(params=['amd64', 'armhf', 'aarch64', 'armel'])
 def arch(request):
     return request.param
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps = -rrequirements.txt
 commands = docker run --rm --privileged multiarch/qemu-user-static:register --reset
            ./Dockerfile.py -v --arch amd64
            pytest -vv -n auto -k amd64 ./test/
-           ./Dockerfile.py -v --arch armhf --arch aarch64
+           ./Dockerfile.py -v --arch armhf --arch aarch64 --arch armel
            pytest -vv -n auto -k armhf ./test/
            pytest -vv -n auto -k aarch64 ./test/
+           pytest -vv -n auto -k armel ./test/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a build stage to the Dockerfiles that can be used to build pihole-FTL binary for the ARMv6.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- https://github.com/pi-hole/docker-pi-hole/issues/245
- https://www.reddit.com/r/pihole/comments/9rr998/problems_with_official_pihole_docker_container_on/e8jy3t0

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Automated tests found in repo
- Pi Zero
- Deployed to home network on 1st gen Raspberry Pi

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
