### PR TITLE
docker_run.sh: Add env var to specify storage directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ If you're using a Red Hat based distrubution with an SELinux Enforcing policy ad
 
 Volumes are recommended for persisting data across container re-creations for updating images.  The IP lookup variables may not work for everyone, please review their values and hard code IP and IPv6 if necessary.
 
+You can customize where to store persistent data by setting the `PIHOLE_BASE` environment variable when invoking `docker_run.sh` (e.g. `PIHOLE_BASE=/opt/pihole-storage ./docker_run.sh`).  If `PIHOLE_BASE` is not set, files are stored in your current directory when you invoke the script.
+
 Port 443 is to provide a sinkhole for ads that use SSL.  If only port 80 is used, then blocked HTTPS queries will fail to connect to port 443 and may cause long loading times.  Rejecting 443 on your firewall can also serve this same purpose.  Ubuntu firewall example: `sudo ufw reject https`
 
 **Automatic Ad List Updates** - since the 3.0+ release, `cron` is baked into the container and will grab the newest versions of your lists and flush your logs.  **Set your TZ** environment variable to make sure the midnight log rotation syncs up with your timezone's midnight.

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -2,14 +2,17 @@
 
 # https://github.com/pi-hole/docker-pi-hole/blob/master/README.md
 
+PIHOLE_BASE=${PIHOLE_BASE:-$(pwd)}
+[[ -d "$PIHOLE_BASE" ]] || mkdir -p "$PIHOLE_BASE" || { echo "Couldn't create storage directory: $PIHOLE_BASE"; exit 1; }
+
 docker run -d \
     --name pihole \
     -p 53:53/tcp -p 53:53/udp \
     -p 80:80 \
     -p 443:443 \
     -e TZ="America/Chicago" \
-    -v "$(pwd)/etc-pihole/:/etc/pihole/" \
-    -v "$(pwd)/etc-dnsmasq.d/:/etc/dnsmasq.d/" \
+    -v "${PIHOLE_BASE}/etc-pihole/:/etc/pihole/" \
+    -v "${PIHOLE_BASE}/etc-dnsmasq.d/:/etc/dnsmasq.d/" \
     --dns=127.0.0.1 --dns=1.1.1.1 \
     --restart=unless-stopped \
     pihole/pihole:latest

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -2,7 +2,7 @@
 
 # https://github.com/pi-hole/docker-pi-hole/blob/master/README.md
 
-PIHOLE_BASE=${PIHOLE_BASE:-$(pwd)}
+PIHOLE_BASE="${PIHOLE_BASE:-$(pwd)}"
 [[ -d "$PIHOLE_BASE" ]] || mkdir -p "$PIHOLE_BASE" || { echo "Couldn't create storage directory: $PIHOLE_BASE"; exit 1; }
 
 docker run -d \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Currently `docker_run.sh` bind-mounts some directories rooted at the
working directory when the script is invoked.  Add an environment variable
so that this storage location can be specified at invocation time without
having to change to a different directory.

Also creates `PIHOLE_BASE` if it doesn't exist already.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This allows for position independent script invocation (so that you don't have to change to another directory before invoking).

## How Has This Been Tested?

- Ran with `PIHOLE_BASE` set, noted that the directory in `PIHOLE_BASE` was created and files were stored there.
- Verified no regressions when `PIHOLE_BASE` is *not* set (still used `$PWD` as before).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
