### PR TITLE
Add new optional env variable DNS_FQDN_REQUIRED

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ There are other environment variables if you want to customize various things in
 | `DNS2: <IP>`<br/> *Optional* *Default: 8.8.4.4* | Secondary upstream DNS provider, default is google DNS, `no` if only one DNS should used
 | `DNSSEC: <True\|False>`<br/> *Optional* *Default: false* | Enable DNSSEC support
 | `DNS_BOGUS_PRIV: <True\|False>`<br/> *Optional* *Default: true* | Enable forwarding of reverse lookups for private ranges
+| `DNS_FQDN_REQUIRED: <True\|False>`<br/> *Optional* *Default: true* | Never forward non-FQDNs
 | `CONDITIONAL_FORWARDING: <True\|False>`<br/> *Optional* *Default: False* | Enable DNS conditional forwarding for device name resolution
 | `CONDITIONAL_FORWARDING_IP: <Router's IP>`<br/> *Optional* | If conditional forwarding is enabled, set the IP of the local network router
 | `CONDITIONAL_FORWARDING_DOMAIN: <Network Domain>`<br/> *Optional* | If conditional forwarding is enabled, set the domain of the local network router

--- a/start.sh
+++ b/start.sh
@@ -12,6 +12,7 @@ export DNS1
 export DNS2
 export DNSSEC
 export DNS_BOGUS_PRIV
+export DNS_FQDN_REQUIRED
 export INTERFACE
 export DNSMASQ_LISTENING_BEHAVIOUR="$DNSMASQ_LISTENING"
 export IPv6
@@ -47,6 +48,7 @@ prepare_configs
 change_setting "IPV4_ADDRESS" "$ServerIP"
 change_setting "IPV6_ADDRESS" "$ServerIPv6"
 change_setting "DNS_BOGUS_PRIV" "$DNS_BOGUS_PRIV"
+change_setting "DNS_FQDN_REQUIRED" "$DNS_FQDN_REQUIRED"
 change_setting "DNSSEC" "$DNSSEC"
 change_setting "CONDITIONAL_FORWARDING" "$CONDITIONAL_FORWARDING"
 change_setting "CONDITIONAL_FORWARDING_IP" "$CONDITIONAL_FORWARDING_IP"


### PR DESCRIPTION
## Description

This new optional env variable will allow control over the 'Never
forward non-FQDNs' advanced DNS setting.  It defaults to 'true' which is the default pihole behavior as well.

## Motivation and Context

There is currently no way to set at startup-time the advanced DNS setting for 'Never
forward non-FQDNs'.  This change allows control over the initial setting.

## How Has This Been Tested?

I have used a container to test the changes as there already is support for a function which changes settings.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
