### PR TITLE
Add to Ubuntu install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ The stub resolver should be disabled with: `sudo sed -r -i.orig 's/#?DNSStubList
 
 This will not change the nameserver settings, which point to the stub resolver thus preventing DNS resolution. Change the `/etc/resolv.conf` symlink to point to `/run/systemd/resolve/resolv.conf`, which is automatically updated to follow the system's [`netplan`](https://netplan.io/):
 `sudo sh -c 'rm /etc/resolv.conf && ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf'`
+After making these changes, you should restart systemd-resolved using `systemctl restart systemd-resolved`
 
 Once pi-hole is installed, you'll want to configure your clients to use it ([see here](https://discourse.pi-hole.net/t/how-do-i-configure-my-devices-to-use-pi-hole-as-their-dns-server/245)). If you used the symlink above, your docker host will either use whatever is served by DHCP, or whatever static setting you've configured. If you want to explicitly set your docker host's nameservers you can edit the netplan(s) found at `/etc/netplan`, then run `sudo netplan apply`.
 Example netplan:


### PR DESCRIPTION
Add info about restarting systemd-resolved

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
I was in the process of installing this onto my Ubuntu server and ran into some conflicts on port 53. The documentation added recently to the README about systemd-resolved led me to the right place. I made the necessary changes, and it did not work. Examining the [basic install script](https://github.com/pi-hole/pi-hole/blob/master/automated%20install/basic-install.sh) at line 1540 I found that the install script restarted systemd-resolved. I did not realize that this was necessary, but this did lead me to fixing the issue. I believe it would make sense to mention restarting systemd-resolved is required (I think it is atleast) to help anyone who ran into the same problem as me.

## How Has This Been Tested?
No testing needed, just a documentation update.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
I don't think any of these apply, it is only an addition to the documentation.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
