### PR TITLE
Old style exceptions -> new style for Python 3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 docker-compose
 jinja2
-pytest>=3.6.0
+pytest>=4.6.7
 pytest-cov
 pytest-xdist
 testinfra==1.5.1

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -178,7 +178,7 @@ def Slow():
         while True:
             try:
                 assert check()
-            except AssertionError, e:
+            except AssertionError as e:
                 if time.time() < timeout_at:
                     time.sleep(1)
                 else:


### PR DESCRIPTION
Old style exceptions are syntax errors in Python 3 but new style exceptions work as expected in both Python 2 and Python 3.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
