### PR TITLE
Fix docker_run.sh syntax

### DIFF
--- a/docker_run.sh
+++ b/docker_run.sh
@@ -2,6 +2,7 @@
 
 # https://github.com/pi-hole/docker-pi-hole/blob/master/README.md
 
+# Note: ServerIP should be replaced with your external ip.
 docker run -d \
     --name pihole \
     -p 53:53/tcp -p 53:53/udp \
@@ -15,7 +16,7 @@ docker run -d \
     --hostname pi.hole \
     -e VIRTUAL_HOST="pi.hole" \
     -e PROXY_LOCATION="pi.hole" \
-    -e ServerIP="127.0.0.1" \ # should be replaced with your external ip
+    -e ServerIP="127.0.0.1" \
     pihole/pihole:latest
 
 printf 'Starting up pihole container '


### PR DESCRIPTION
The trailing backslash must be the last character on the line for it to
be interpreted as a continuation command.

Signed-off-by: Fazlul Shahriar <fshahriar@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
