### PR TITLE
Consequently use /run instead of /var/run

### DIFF
--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -21,7 +21,7 @@ prepare_configs() {
     installConfigs
     touch "$setupVars"
     set +e
-    mkdir -p /var/run/pihole /var/log/pihole
+    mkdir -p /run/pihole /var/log/pihole
     # Re-apply perms from basic-install over any volume mounts that may be present (or not)
     # Also  similar to preflights for FTL https://github.com/pi-hole/pi-hole/blob/master/advanced/Templates/pihole-FTL.service
     chown pihole:root /etc/lighttpd
@@ -30,8 +30,8 @@ prepare_configs() {
     # not sure why pihole:pihole user/group write perms are not enough for web to write...dirty fix:
     chmod 777 "${regexFile}"
     touch /var/log/pihole-FTL.log /run/pihole-FTL.pid /run/pihole-FTL.port /var/log/pihole.log
-    chown pihole:pihole /var/run/pihole /var/log/pihole
-    test -f /var/run/pihole/FTL.sock && rm /var/run/pihole/FTL.sock
+    chown pihole:pihole /run/pihole /var/log/pihole
+    test -f /run/pihole/FTL.sock && rm /run/pihole/FTL.sock
     chown pihole:pihole /var/log/pihole-FTL.log /run/pihole-FTL.pid /run/pihole-FTL.port /etc/pihole /etc/pihole/dhcp.leases /var/log/pihole.log
     chmod 0644 /var/log/pihole-FTL.log /run/pihole-FTL.pid /run/pihole-FTL.port /var/log/pihole.log
     set -e

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 mkdir -p /etc/pihole/
-mkdir -p /var/run/pihole
+mkdir -p /run/pihole
 # Production tags with valid web footers
 export CORE_VERSION="$(cat /etc/docker-pi-hole-version)"
 export WEB_VERSION="${CORE_VERSION}"


### PR DESCRIPTION
Companion PR to: https://github.com/pi-hole/pi-hole/pull/3248

Signed-off-by: MichaIng <micha@dietpi.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Consequently use `/run` instead of deprecated `/var/run` for runtime files, to satisfy FHS and systemd and avoid confusion because of conflicting paths, which are valid only because of `/var/run -> /run` symlink.

## Motivation and Context
See: https://github.com/pi-hole/pi-hole/pull/3248#issuecomment-609713592

## How Has This Been Tested?
It has not been tested, however the rationale behind it is assumed trivial enough. A test can be done, if wanted.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Satisfy code and setup standards and consistency, to pro-actively avoid possible future issues and reduce chance for confusion.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly: https://github.com/pi-hole/docs/pull/313