### PR TITLE
Make buster the default debian version

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,8 @@ The primary docker tags / versions are explained in the following table.  [Click
 | ---                     | ------------ | -----------                                                             | ---------- |
 | `latest`                | auto detect  | x86, arm, or arm64 container, docker auto detects your architecture.    | [Dockerfile](https://github.com/pi-hole/docker-pi-hole/blob/master/Dockerfile) |
 | `v5.0`                  | auto detect  | Versioned tags, if you want to pin against a specific Pi-hole version, use one of these |  |
-| `v5.0-stretch`          | auto detect  | Versioned tags, if you want to pin against a specific Pi-hole and Debian version, use one of these |  |
-| `v5.0-<arch>-stretch`   | based on tag | Specific architectures and Debian version tags | |
+| `v5.0-buster`           | auto detect  | Versioned tags, if you want to pin against a specific Pi-hole and Debian version, use one of these |  |
+| `v5.0-<arch>-buster `   | based on tag | Specific architectures and Debian version tags | |
 | `dev`                   | auto detect  | like latest tag, but for the development branch (pushed occasionally)   | |
 
 ### `pihole/pihole:latest` [![](https://images.microbadger.com/badges/image/pihole/pihole:latest.svg)](https://microbadger.com/images/pihole/pihole "Get your own image badge on microbadger.com") [![](https://images.microbadger.com/badges/version/pihole/pihole:latest.svg)](https://microbadger.com/images/pihole/pihole "Get your own version badge on microbadger.com") [![](https://images.microbadger.com/badges/version/pihole/pihole:latest.svg)](https://microbadger.com/images/pihole/pihole "Get your own version badge on microbadger.com")

--- a/build.yml
+++ b/build.yml
@@ -12,38 +12,38 @@ x-common-args: &common-args
 
 services:
   amd64:
-    image: pihole:${PIHOLE_VERSION}-amd64-${DEBIAN_VERSION:-stretch}
+    image: pihole:${PIHOLE_VERSION}-amd64-${DEBIAN_VERSION:-buster}
     build:
       context: .
       args:
         <<: *common-args
-        PIHOLE_BASE: pihole/debian-base:${DEBIAN_VERSION:-stretch}
+        PIHOLE_BASE: pihole/debian-base:${DEBIAN_VERSION:-buster}
         PIHOLE_ARCH: amd64
         S6_ARCH: amd64
   armel:
-    image: pihole:${PIHOLE_VERSION}-armel-${DEBIAN_VERSION:-stretch}
+    image: pihole:${PIHOLE_VERSION}-armel-${DEBIAN_VERSION:-buster}
     build:
       context: .
       args:
         <<: *common-args
-        PIHOLE_BASE: multiarch/debian-debootstrap:armel-${DEBIAN_VERSION:-stretch}-slim
+        PIHOLE_BASE: multiarch/debian-debootstrap:armel-${DEBIAN_VERSION:-buster}-slim
         PIHOLE_ARCH: armel
         S6_ARCH: arm
   armhf:
-    image: pihole:${PIHOLE_VERSION}-armhf-${DEBIAN_VERSION:-stretch}
+    image: pihole:${PIHOLE_VERSION}-armhf-${DEBIAN_VERSION:-buster}
     build:
       context: .
       args:
         <<: *common-args
-        PIHOLE_BASE: multiarch/debian-debootstrap:armhf-${DEBIAN_VERSION:-stretch}-slim
+        PIHOLE_BASE: multiarch/debian-debootstrap:armhf-${DEBIAN_VERSION:-buster}-slim
         PIHOLE_ARCH: arm
         S6_ARCH: arm
   arm64:
-    image: pihole:${PIHOLE_VERSION}-arm64-${DEBIAN_VERSION:-stretch}
+    image: pihole:${PIHOLE_VERSION}-arm64-${DEBIAN_VERSION:-buster}
     build:
       context: .
       args:
         <<: *common-args
-        PIHOLE_BASE: multiarch/debian-debootstrap:arm64-${DEBIAN_VERSION:-stretch}-slim
+        PIHOLE_BASE: multiarch/debian-debootstrap:arm64-${DEBIAN_VERSION:-buster}-slim
         PIHOLE_ARCH: arm64
         S6_ARCH: aarch64

--- a/gh-actions-test.sh
+++ b/gh-actions-test.sh
@@ -5,7 +5,7 @@ set -ex
 #
 # @environment ${ARCH}              The architecture to build. Example: amd64.
 # @environment ${DEBIAN_VERSION}    Debian version to build. ('buster' or 'stretch').
-# @environment ${ARCH_IMAGE}        What the Docker Hub Image should be tagged as. Example: pihole/pihole:master-amd64-stretch
+# @environment ${ARCH_IMAGE}        What the Docker Hub Image should be tagged as. Example: pihole/pihole:master-amd64-buster
 
 # setup qemu/variables
 docker run --rm --privileged multiarch/qemu-user-static:register --reset > /dev/null

--- a/gh-actions-vars.sh
+++ b/gh-actions-vars.sh
@@ -2,14 +2,14 @@
 set -a
 
 # @environment ${ARCH}                    The architecture to build. Defaults to 'amd64'.
-# @environment ${DEBIAN_VERSION}          Debian version to build. Defaults to 'stretch'.
+# @environment ${DEBIAN_VERSION}          Debian version to build. Defaults to 'buster'.
 # @environment ${DOCKER_HUB_REPO}         The docker hub repo to tag images for. Defaults to 'pihole'.
 # @environment ${DOCKER_HUB_IMAGE_NAME}   The name of the resulting image. Defaults to 'pihole'.
 
 GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD | sed "s/\//-/g")
 GIT_TAG=$(git describe --tags --exact-match 2> /dev/null || true)
 
-DEFAULT_DEBIAN_VERSION="stretch"
+DEFAULT_DEBIAN_VERSION="buster"
 
 if [[ -z "${ARCH}" ]]; then
     ARCH="amd64"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -9,7 +9,7 @@ import types
 local_host = testinfra.get_host('local://')
 check_output = local_host.check_output
 
-DEBIAN_VERSION = os.environ.get('DEBIAN_VERSION', 'stretch')
+DEBIAN_VERSION = os.environ.get('DEBIAN_VERSION', 'buster')
 __version__ = None
 dotdot = os.path.abspath(os.path.join(os.path.abspath(__file__), os.pardir, os.pardir))
 with open('{}/VERSION'.format(dotdot), 'r') as v:

--- a/test/test_volume_data.sh
+++ b/test/test_volume_data.sh
@@ -33,7 +33,7 @@ trap "cleanup" INT TERM EXIT
 # VOLUME TESTS
 
 # Given...
-DEBIAN_VERSION="$(DEBIAN_VERSION:-stretch)"
+DEBIAN_VERSION="$(DEBIAN_VERSION:-buster)"
 IMAGE="${1:-pihole:v5.0-amd64}-${DEBIAN_VERSION}"   # Default is latest build test image (generic, non release/branch tag)
 VOLUMES="$(mktemp -d)"                              # A fresh volume directory
 VOL_PH="$VOLUMES/pihole"


### PR DESCRIPTION
Make buster the default debian version. Stretch is LTS and the tag still exists for those who need it, but its time to move on (IMHO).

## Description
Make the `latest` and non-os-specific tags use the buster version. Keep the stretch tags around for those who need it. This will probably break things for some people who are relying on the stretch version but are not using the stretch tags, the OS-specific tags are still kinda new and never got a lot of attention - so I doubt many people are using it. I've marked it as a 'breaking' change because of this, but isn't exactly breaking since people can just update their tags to use whichever version they like.

* `latest` -> `buster`
* `vX.X.X` -> `buster`
* `vX.X.X-buster` -> `buster`
* `vX.X.X-stretch` -> `stretch`

## Motivation and Context

Stretch is LTS, Buster is current, Bullseye is around the corner.

## How Has This Been Tested?

I've been running buster for a couple months now without issue, but I haven't tested this tag change specifically. Hopefully Github Actions will yell at me if I missed something.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
