### PR TITLE
Docker run script tweak to fix pi.hole resolution

### DIFF
--- a/docker_run.sh
+++ b/docker_run.sh
@@ -16,7 +16,7 @@ docker run -d \
     -v "${PIHOLE_BASE}/etc-dnsmasq.d/:/etc/dnsmasq.d/" \
     --dns=127.0.0.1 --dns=1.1.1.1 \
     --restart=unless-stopped \
-    --hostname pi.hole \
+    --hostname pihole \
     -e VIRTUAL_HOST="pi.hole" \
     -e PROXY_LOCATION="pi.hole" \
     -e ServerIP="127.0.0.1" \
@@ -34,7 +34,7 @@ for i in $(seq 1 20); do
     fi
 
     if [ $i -eq 20 ] ; then
-        echo -e "\nTimed out waiting for Pi-hole start, consult check your container logs for more info (\`docker logs pihole\`)"
+        echo -e "\nTimed out waiting for Pi-hole start, check your container logs for more info (\`docker logs pihole\`)"
         exit 1
     fi
 done;


### PR DESCRIPTION
## Description
Changed the default hostname in docker_run.sh to avoid conflicting with the admin interface domain. Also tweaked wording.

## Motivation and Context
Fixes #553 - see: https://github.com/pi-hole/docker-pi-hole/issues/553#issuecomment-640240148 and onward.

If a container is created with hostname `pi.hole`, it gets added to `/etc/hosts` with the IP address of the container. This makes Pi-Hole respond to a DNS query for `pi.hole` with the internal container IP address, instead of the address set using the `ServerIP` environment variable, thus making the admin interface inaccesible via `http://pi.hole`.

## How Has This Been Tested?
I just used the command to spin up my new Pihole.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
