### PR TITLE
Bugfix: Fix broken sed tests

### DIFF
--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -1,4 +1,4 @@
-FROM python:buster
+FROM python:3.8-buster
 
 # Only works for docker CLIENT (bind mounted socket)
 COPY --from=docker:18.09.3 /usr/local/bin/docker /usr/local/bin/


### PR DESCRIPTION
## Description
The test build image is using `sed` with a specific version of python. Lock python version to `3.8` so that updates do no break the tests.

## Motivation and Context
Broken tests are annoying

## How Has This Been Tested?
The test is if the PR reports success or not, 🤞 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
