### PR TITLE
Update documentation of CONDITIONAL_FORWARDING_REVERSE for 5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ There are other environment variables if you want to customize various things in
 | `CONDITIONAL_FORWARDING: <"true"\|"false">`<br/> *Optional* *Default: "false"* | Enable DNS conditional forwarding for device name resolution
 | `CONDITIONAL_FORWARDING_IP: <Router's IP>`<br/> *Optional* | If conditional forwarding is enabled, set the IP of the local network router
 | `CONDITIONAL_FORWARDING_DOMAIN: <Network Domain>`<br/> *Optional* | If conditional forwarding is enabled, set the domain of the local network router
-| `CONDITIONAL_FORWARDING_REVERSE: <Reverse DNS>`<br/> *Optional* | If conditional forwarding is enabled, set the reverse DNS of the local network router (e.g. `0.168.192.in-addr.arpa`)
+| `CONDITIONAL_FORWARDING_REVERSE: <Reverse DNS>`<br/> *Optional* | If conditional forwarding is enabled, set the reverse DNS zone (e.g. `192.168.0.0/24`)
 | `ServerIP: <Host's IP>`<br/> **Recommended** | **--net=host mode requires** Set to your server's LAN IP, used by web block modes and lighttpd bind address
 | `ServerIPv6: <Host's IPv6>`<br/> *Required if using IPv6* | **If you have a v6 network** set to your server's LAN IPv6 to block IPv6 ads fully
 | `VIRTUAL_HOST: <Custom Hostname>`<br/> *Optional* *Default: $ServerIP*   | What your web server 'virtual host' is, accessing admin through this Hostname/IP allows you to make changes to the whitelist / blacklists in addition to the default 'http://pi.hole/admin/' address


### PR DESCRIPTION
https://github.com/pi-hole/pi-hole/pull/3761 has changed the semantics of the `CONDITIONAL_FORWARDING_REVERSE` environment variable. Following the previously documented example led to FTL syntax errors (see https://discourse.pi-hole.net/t/ftl-failed-to-start/40950).

## Description

This is a follow-up for https://github.com/pi-hole/pi-hole/pull/3761 to implement the documentation fixes as described in the "What documentation changes (if any) are needed to support this PR" section of the referenced PR.

## Motivation and Context

Updating to 5.2 breaks every container using `CONDITIONAL_FORWARDING`.


## How Has This Been Tested?

Docs fixes only.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
