### PR TITLE
Introduce new REV_SERVER environment variables. Deprecate CONDITIONAL_FORWARDING ones, but maintain backward compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ There are other environment variables if you want to customize various things in
 | `SKIPGRAVITYONBOOT`: <Not Set\|1><br/> *Optional Default: Not Set* | Use this option to skip updating the Gravity Database when booting up the container.  By default this environment variable is not set so the Gravity Database will be updated when the container starts up.  Setting this environment variable to 1 (or anything) will cause the Gravity Database to not be updated when container starts up.
 
 ## Deprecated environment variables:
-While these may still work, they are likely to be removed in a future version. Where applicible, alternative variable names are indicated
+While these may still work, they are likely to be removed in a future version. Where applicible, alternative variable names are indicated. Please review the table above for usage of the alternative variables
 
 | Docker Environment Var. | Description | Replaced By |
 | ----------------------- | ----------- | ----------- |

--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ There are other environment variables if you want to customize various things in
 | `DNSSEC: <"true"\|"false">`<br/> *Optional* *Default: "false"* | Enable DNSSEC support
 | `DNS_BOGUS_PRIV: <"true"\|"false">`<br/> *Optional* *Default: "true"* | Enable forwarding of reverse lookups for private ranges
 | `DNS_FQDN_REQUIRED: <"true"\|"false">`<br/> *Optional* *Default: true* | Never forward non-FQDNs
-| `CONDITIONAL_FORWARDING: <"true"\|"false">`<br/> *Optional* *Default: "false"* | Enable DNS conditional forwarding for device name resolution
-| `CONDITIONAL_FORWARDING_IP: <Router's IP>`<br/> *Optional* | If conditional forwarding is enabled, set the IP of the local network router
-| `CONDITIONAL_FORWARDING_DOMAIN: <Network Domain>`<br/> *Optional* | If conditional forwarding is enabled, set the domain of the local network router
-| `CONDITIONAL_FORWARDING_REVERSE: <Reverse DNS>`<br/> *Optional* | If conditional forwarding is enabled, set the reverse DNS of the local network router (e.g. `0.168.192.in-addr.arpa`)
+| `REV_SERVER: <"true"\|"false">`<br/> *Optional* *Default: "false"* | Enable DNS conditional forwarding for device name resolution
+| `REV_SERVER_DOMAIN: <Network Domain>`<br/> *Optional* | If conditional forwarding is enabled, set the domain of the local network router
+| `REV_SERVER_TARGET: <Router's IP>`<br/> *Optional* | If conditional forwarding is enabled, set the IP of the local network router
+| `REV_SERVER_CIDR: <Reverse DNS>`<br/> *Optional* | If conditional forwarding is enabled, set the reverse DNS zone (e.g. `192.168.0.0/24`)
 | `ServerIP: <Host's IP>`<br/> **Recommended** | **--net=host mode requires** Set to your server's LAN IP, used by web block modes and lighttpd bind address
 | `ServerIPv6: <Host's IPv6>`<br/> *Required if using IPv6* | **If you have a v6 network** set to your server's LAN IPv6 to block IPv6 ads fully
 | `VIRTUAL_HOST: <Custom Hostname>`<br/> *Optional* *Default: $ServerIP*   | What your web server 'virtual host' is, accessing admin through this Hostname/IP allows you to make changes to the whitelist / blacklists in addition to the default 'http://pi.hole/admin/' address
@@ -122,6 +122,16 @@ There are other environment variables if you want to customize various things in
 | `TEMPERATUREUNIT`: <c\|k\|f><br/>*Optional Default: c* | Set preferred temperature unit to `c`: Celsius, `k`: Kelvin, or `f` Fahrenheit units.
 | `WEBUIBOXEDLAYOUT: <boxed\|traditional>`<br/>*Optional Default: boxed* | Use boxed layout (helpful when working on large screens)
 | `SKIPGRAVITYONBOOT`: <Not Set\|1><br/> *Optional Default: Not Set* | Use this option to skip updating the Gravity Database when booting up the container.  By default this environment variable is not set so the Gravity Database will be updated when the container starts up.  Setting this environment variable to 1 (or anything) will cause the Gravity Database to not be updated when container starts up.
+
+## Deprecated environment variables:
+While these may still work, they are likely to be removed in a future version. Where applicible, alternative variable names are indicated
+
+| Docker Environment Var. | Description | Replaced By |
+| ----------------------- | ----------- | ----------- |
+| `CONDITIONAL_FORWARDING: <"true"\|"false">`<br/> *Optional* *Default: "false"* | Enable DNS conditional forwarding for device name resolution | `REV_SERVER`|
+| `CONDITIONAL_FORWARDING_IP: <Router's IP>`<br/> *Optional* | If conditional forwarding is enabled, set the IP of the local network router | `REV_SERVER_TARGET` |
+| `CONDITIONAL_FORWARDING_DOMAIN: <Network Domain>`<br/> *Optional* | If conditional forwarding is enabled, set the domain of the local network router | `REV_SERVER_DOMAIN` | 
+| `CONDITIONAL_FORWARDING_REVERSE: <Reverse DNS>`<br/> *Optional* | If conditional forwarding is enabled, set the reverse DNS of the local network router (e.g. `0.168.192.in-addr.arpa`) | `REV_SERVER_CIDR` |
 
 To use these env vars in docker run format style them like: `-e DNS1=1.1.1.1`
 

--- a/start.sh
+++ b/start.sh
@@ -17,6 +17,10 @@ export INTERFACE
 export DNSMASQ_LISTENING_BEHAVIOUR="$DNSMASQ_LISTENING"
 export IPv6
 export WEB_PORT
+export REV_SERVER
+export REV_SERVER_DOMAIN
+export REV_SERVER_TARGET
+export REV_SERVER_CIDR
 export CONDITIONAL_FORWARDING
 export CONDITIONAL_FORWARDING_IP
 export CONDITIONAL_FORWARDING_DOMAIN
@@ -61,10 +65,18 @@ change_setting "IPV6_ADDRESS" "$ServerIPv6"
 change_setting "DNS_BOGUS_PRIV" "$DNS_BOGUS_PRIV"
 change_setting "DNS_FQDN_REQUIRED" "$DNS_FQDN_REQUIRED"
 change_setting "DNSSEC" "$DNSSEC"
-change_setting "CONDITIONAL_FORWARDING" "$CONDITIONAL_FORWARDING"
-change_setting "CONDITIONAL_FORWARDING_IP" "$CONDITIONAL_FORWARDING_IP"
-change_setting "CONDITIONAL_FORWARDING_DOMAIN" "$CONDITIONAL_FORWARDING_DOMAIN"
-change_setting "CONDITIONAL_FORWARDING_REVERSE" "$CONDITIONAL_FORWARDING_REVERSE"
+change_setting "REV_SERVER"="$REV_SERVER"
+change_setting "REV_SERVER_DOMAIN"="$REV_SERVER_DOMAIN"
+change_setting "REV_SERVER_TARGET"="$REV_SERVER_TARGET"
+change_setting "REV_SERVER_CIDR"="$REV_SERVER_CIDR"
+if [ -z "$REV_SERVER" ];then
+    # If the REV_SERVER* variables are set, then there is no need to add these.
+    # If it is not set, then adding these variables is fine, and they will be converted by the Pi-hole install script
+    change_setting "CONDITIONAL_FORWARDING" "$CONDITIONAL_FORWARDING"
+    change_setting "CONDITIONAL_FORWARDING_IP" "$CONDITIONAL_FORWARDING_IP"
+    change_setting "CONDITIONAL_FORWARDING_DOMAIN" "$CONDITIONAL_FORWARDING_DOMAIN"
+    change_setting "CONDITIONAL_FORWARDING_REVERSE" "$CONDITIONAL_FORWARDING_REVERSE"
+fi
 setup_web_port "$WEB_PORT"
 setup_web_password "$WEBPASSWORD"
 setup_temp_unit "$TEMPERATUREUNIT"

--- a/start.sh
+++ b/start.sh
@@ -65,10 +65,10 @@ change_setting "IPV6_ADDRESS" "$ServerIPv6"
 change_setting "DNS_BOGUS_PRIV" "$DNS_BOGUS_PRIV"
 change_setting "DNS_FQDN_REQUIRED" "$DNS_FQDN_REQUIRED"
 change_setting "DNSSEC" "$DNSSEC"
-change_setting "REV_SERVER"="$REV_SERVER"
-change_setting "REV_SERVER_DOMAIN"="$REV_SERVER_DOMAIN"
-change_setting "REV_SERVER_TARGET"="$REV_SERVER_TARGET"
-change_setting "REV_SERVER_CIDR"="$REV_SERVER_CIDR"
+change_setting "REV_SERVER" "$REV_SERVER"
+change_setting "REV_SERVER_DOMAIN" "$REV_SERVER_DOMAIN"
+change_setting "REV_SERVER_TARGET" "$REV_SERVER_TARGET"
+change_setting "REV_SERVER_CIDR" "$REV_SERVER_CIDR"
 if [ -z "$REV_SERVER" ];then
     # If the REV_SERVER* variables are set, then there is no need to add these.
     # If it is not set, then adding these variables is fine, and they will be converted by the Pi-hole install script


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Companion PR to be merged **_only after_** (and if) https://github.com/pi-hole/pi-hole/pull/3882 is accepted and merged /released

## Motivation and Context
The CONDITIONAL_FORWARDING variables have been replaced with REV_SERVER variables - this allows a docker user to specify them in their environment variables, whilst maintaining backward compatibility for the old style ones to be used (and transformed by the core repo)

## How Has This Been Tested?
I've not tested the docker image - honestly I'm not entirely sure how

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
