### PR TITLE
Upgrade s6-overlay to v2.1.0.2

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -5,7 +5,7 @@ x-common-args: &common-args
   PIHOLE_VERSION: ${PIHOLE_VERSION}
   NAME: pihole/pihole
   MAINTAINER: adam@diginc.us
-  S6_VERSION: v1.22.1.0
+  S6_VERSION: v2.1.0.2
   PHP_ENV_CONFIG: /etc/lighttpd/conf-enabled/15-fastcgi-php.conf
   PHP_ERROR_LOG: /var/log/lighttpd/error.log
 


### PR DESCRIPTION
## Description
Upgrade s6-overlay from v1.22.1.0 to v2.1.0.2 (latest release):
https://github.com/just-containers/s6-overlay/releases/tag/v2.1.0.2

## Motivation and Context
Upgrade notes:
https://github.com/just-containers/s6-overlay#upgrade-notes

## How Has This Been Tested?
docker-compose up -d --build (works for me)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
