### PR TITLE
Re-jig how Pi-hole's upstream DNS servers are set

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,7 @@ There are other environment variables if you want to customize various things in
 | `ADMIN_EMAIL: <email address>`<br/> *Optional Default: ''* | Set an administrative contact address for the Block Page
 | `TZ: <Timezone>`<br/> **Recommended** *Default: UTC* | Set your [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) to make sure logs rotate at local midnight instead of at UTC midnight.
 | `WEBPASSWORD: <Admin password>`<br/> **Recommended** *Default: random* | http://pi.hole/admin password. Run `docker logs pihole \| grep random` to find your random pass.
-| `DNS1: <IP>`<br/> *Optional* *Default: 8.8.8.8* | Primary upstream DNS provider, default is google DNS
-| `DNS2: <IP>`<br/> *Optional* *Default: 8.8.4.4* | Secondary upstream DNS provider, default is google DNS, `no` if only one DNS should used
+| `PIHOLE_DNS_: <IPs delimited by ;>`<br/> *Optional* *Default: 8.8.8.8;8.8.4.4* | Upstream DNS server(s) for Pi-hole to forward queries to, seperated by a semicolon <br/> (supports non-standard ports with `#[port number]`) e.g `127.0.0.1#5053;8.8.8.8;8.8.4.4`
 | `DNSSEC: <"true"\|"false">`<br/> *Optional* *Default: "false"* | Enable DNSSEC support
 | `DNS_BOGUS_PRIV: <"true"\|"false">`<br/> *Optional* *Default: "true"* | Enable forwarding of reverse lookups for private ranges
 | `DNS_FQDN_REQUIRED: <"true"\|"false">`<br/> *Optional* *Default: true* | Never forward non-FQDNs
@@ -131,8 +130,10 @@ While these may still work, they are likely to be removed in a future version. W
 | ----------------------- | ----------- | ----------- |
 | `CONDITIONAL_FORWARDING: <"true"\|"false">`<br/> *Optional* *Default: "false"* | Enable DNS conditional forwarding for device name resolution | `REV_SERVER`|
 | `CONDITIONAL_FORWARDING_IP: <Router's IP>`<br/> *Optional* | If conditional forwarding is enabled, set the IP of the local network router | `REV_SERVER_TARGET` |
-| `CONDITIONAL_FORWARDING_DOMAIN: <Network Domain>`<br/> *Optional* | If conditional forwarding is enabled, set the domain of the local network router | `REV_SERVER_DOMAIN` | 
+| `CONDITIONAL_FORWARDING_DOMAIN: <Network Domain>`<br/> *Optional* | If conditional forwarding is enabled, set the domain of the local network router | `REV_SERVER_DOMAIN` |
 | `CONDITIONAL_FORWARDING_REVERSE: <Reverse DNS>`<br/> *Optional* | If conditional forwarding is enabled, set the reverse DNS of the local network router (e.g. `0.168.192.in-addr.arpa`) | `REV_SERVER_CIDR` |
+| `DNS1: <IP>`<br/> *Optional* *Default: 8.8.8.8* | Primary upstream DNS provider, default is google DNS | `PIHOLE_DNS_` |
+| `DNS2: <IP>`<br/> *Optional* *Default: 8.8.4.4* | Secondary upstream DNS provider, default is google DNS, `no` if only one DNS should used | `PIHOLE_DNS_` |
 
 To use these env vars in docker run format style them like: `-e DNS1=1.1.1.1`
 

--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -66,16 +66,6 @@ validate_env() {
     fi;
 }
 
-setup_dnsmasq_dns() {
-    . /opt/pihole/webpage.sh
-    local DNS1="8.8.8.8"
-    local DNS2="8.8.4.4"
-
-    echo "Configuring default DNS servers: $DNS1 & $DNS2"
-    change_setting "PIHOLE_DNS_1" "${DNS1}"
-    change_setting "PIHOLE_DNS_2" "${DNS2}"
-}
-
 setup_dnsmasq_interface() {
     local interface="${1:-eth0}"
     local interfaceType='default'
@@ -102,12 +92,10 @@ setup_dnsmasq_config_if_missing() {
 }
 
 setup_dnsmasq() {
-    local USE_DEFAULT_DNS_SERVERS="$1"
-    local interface="$2"
-    local dnsmasq_listening_behaviour="$3"
+    local interface="$1"
+    local dnsmasq_listening_behaviour="$2"
     # Coordinates
     setup_dnsmasq_config_if_missing
-    [ $USE_DEFAULT_DNS_SERVERS -eq 1 ] && setup_dnsmasq_dns
     setup_dnsmasq_interface "$interface"
     setup_dnsmasq_listening_behaviour "$dnsmasq_listening_behaviour"
     setup_dnsmasq_user "${DNSMASQ_USER}"

--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -68,39 +68,12 @@ validate_env() {
 
 setup_dnsmasq_dns() {
     . /opt/pihole/webpage.sh
-    local DNS1="${1:-8.8.8.8}"
-    local DNS2="${2:-8.8.4.4}"
-    local dnsType='default'
-    if [ "$DNS1" != '8.8.8.8' ] || [ "$DNS2" != '8.8.4.4' ] ; then
-        dnsType='custom'
-    fi;
+    local DNS1="8.8.8.8"
+    local DNS2="8.8.4.4"
 
-    # TODO With the addition of this to /start.sh this needs a refactor
-    if [ ! -f /.piholeFirstBoot ] ; then
-        local setupDNS1="$(grep 'PIHOLE_DNS_1' ${setupVars})"
-        local setupDNS2="$(grep 'PIHOLE_DNS_2' ${setupVars})"
-        setupDNS1="${setupDNS1/PIHOLE_DNS_1=/}"
-        setupDNS2="${setupDNS2/PIHOLE_DNS_2=/}"
-        if [[ -n "$DNS1" && -n "$setupDNS1"  ]] || \
-           [[ -n "$DNS2" && -n "$setupDNS2"  ]] ; then
-                echo "Docker DNS variables not used"
-        fi
-        echo "Existing DNS servers used (${setupDNS1:-unset} & ${setupDNS2:-unset})"
-        return
-    fi
-
-    echo "Using $dnsType DNS servers: $DNS1 & $DNS2"
-    if [[ -n "$DNS1" && -z "$setupDNS1" ]] ; then
-        change_setting "PIHOLE_DNS_1" "${DNS1}"
-    fi
-    if [[ -n "$DNS2" && -z "$setupDNS2" ]] ; then
-        if [[ "$DNS2" == "no" ]] ; then
-            delete_setting "PIHOLE_DNS_2"
-            unset PIHOLE_DNS_2
-        else
-            change_setting "PIHOLE_DNS_2" "${DNS2}"
-        fi
-    fi
+    echo "Configuring default DNS servers: $DNS1 & $DNS2"
+    change_setting "PIHOLE_DNS_1" "${DNS1}"
+    change_setting "PIHOLE_DNS_2" "${DNS2}"
 }
 
 setup_dnsmasq_interface() {
@@ -129,13 +102,12 @@ setup_dnsmasq_config_if_missing() {
 }
 
 setup_dnsmasq() {
-    local dns1="$1"
-    local dns2="$2"
-    local interface="$3"
-    local dnsmasq_listening_behaviour="$4"
+    local USE_DEFAULT_DNS_SERVERS="$1"
+    local interface="$2"
+    local dnsmasq_listening_behaviour="$3"
     # Coordinates
     setup_dnsmasq_config_if_missing
-    setup_dnsmasq_dns "$dns1" "$dns2"
+    [ $USE_DEFAULT_DNS_SERVERS -eq 1 ] && setup_dnsmasq_dns
     setup_dnsmasq_interface "$interface"
     setup_dnsmasq_listening_behaviour "$dnsmasq_listening_behaviour"
     setup_dnsmasq_user "${DNSMASQ_USER}"

--- a/start.sh
+++ b/start.sh
@@ -29,6 +29,7 @@ export TEMPERATUREUNIT
 export ADMIN_EMAIL
 export WEBUIBOXEDLAYOUT
 export QUERY_LOGGING
+export PIHOLE_DNS_
 
 export adlistFile='/etc/pihole/adlists.list'
 
@@ -81,12 +82,40 @@ if [ -z "$REV_SERVER" ];then
     [ -n "${CONDITIONAL_FORWARDING_REVERSE}" ] && change_setting "CONDITIONAL_FORWARDING_REVERSE" "$CONDITIONAL_FORWARDING_REVERSE"
 fi
 
+if [ -z "${PIHOLE_DNS_}"]; then
+    # For backward compatibility, if DNS1 and/or DNS2 are set, but PIHOLE_DNS_ is not, convert them to
+    # a semi-colon delimited string and store in PIHOLE_DNS_
+    # They are not used anywhere if PIHOLE_DNS_ is set already
+    [ -n "${DNS1}" ] && PIHOLE_DNS_="$DNS1"
+    [[ -n "${DNS2}" && "${DNS2}" != "no" ]] && PIHOLE_DNS_="$PIHOLE_DNS_;$DNS2"
+fi
+
+# Parse the PIHOLE_DNS variable, if it exists, and apply upstream servers to Pi-hole config
+USE_DEFAULT_DNS_SERVERS=1
+if [ -n "${PIHOLE_DNS_}" ]; then
+    # Split into an array (delimited by ;)
+    PIHOLE_DNS_ARR=(${PIHOLE_DNS_//;/ })
+    count=1
+    for i in "${PIHOLE_DNS_ARR[@]}"; do
+        change_setting "PIHOLE_DNS_$count" "$i"
+        ((count=count+1))
+    done
+    # DNS Servers have been set up in this side of the script, so don't set the defaults of 8.8.8.8 and 8.8.4.4
+    USE_DEFAULT_DNS_SERVERS=0
+else
+    # Environment variable has not been set, but there may be existing values in an existing setupVars.conf
+    # if this is the case, we do not want to overwrite these with the defaults of 8.8.8.8 and 8.8.4.4
+    # Pi-hole can run with only one upstream configured, so we will just check for one.
+    setupVarsDNS="$(grep 'PIHOLE_DNS_1' /etc/pihole/setupVars.conf || true)"
+    [ -n "${setupVarsDNS}" ] && USE_DEFAULT_DNS_SERVERS=0 # A configured upstream DNS has been detected in an existing setupvars.conf.
+fi
+
 setup_web_port "$WEB_PORT"
 setup_web_password "$WEBPASSWORD"
 setup_temp_unit "$TEMPERATUREUNIT"
 setup_ui_layout "$WEBUIBOXEDLAYOUT"
 setup_admin_email "$ADMIN_EMAIL"
-setup_dnsmasq "$DNS1" "$DNS2" "$INTERFACE" "$DNSMASQ_LISTENING_BEHAVIOUR"
+setup_dnsmasq "$USE_DEFAULT_DNS_SERVERS" "$INTERFACE" "$DNSMASQ_LISTENING_BEHAVIOUR"
 setup_php_env
 setup_dnsmasq_hostnames "$ServerIP" "$ServerIPv6" "$HOSTNAME"
 setup_ipv4_ipv6


### PR DESCRIPTION
## Description

This PR is another change towards solving #720. It's often mentioned by users that PIHOLE_DNS_1 and _2 are reset on restarts and on rebuilds, falling back to google defaults.

I aim to solve this by introducing a new variable: `PIHOLE_DNS_`, which is defined as a list of IP addresses, delimited by a semicolon (e.g `8.8.8.8;8.8.4.4` - custom ports also accepted, e.g `127.0.0.1#5353`)

A benefit of this over using the existing `DNS1` and `DNS2` variables is that users are not limited to using just 2. If they wish, they can set as many as they like. It also means that they do not have to set `DNS2` to `no` when only wanting to use 1 upstream server.

If `PIHOLE_DNS_` is not set, then any existing `DNS1` and `DNS2` variables will be converted to the `PIHOLE_DNS_` variable. If `DNS1` and `DNS2` are not set, then the script will fall back to the defaults of `8.8.8.8` and `8.8.4.4`

## How Has This Been Tested?
Built the container locally (what seems like thousands of times whilst I debugged 😉) and ran various combinations of the above

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

(not breaking as previous variables are converted)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation. 
- [x] I have updated the documentation accordingly.
