### PR TITLE
Add `hostname` to docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ services:
   pihole:
     container_name: pihole
     image: pihole/pihole:latest
-    hostname: pihole
+    hostname: pi.hole
     ports:
       - "53:53/tcp"
       - "53:53/udp"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ services:
   pihole:
     container_name: pihole
     image: pihole/pihole:latest
+    hostname: pihole
     ports:
       - "53:53/tcp"
       - "53:53/udp"

--- a/docker-compose-jwilder-proxy.yml
+++ b/docker-compose-jwilder-proxy.yml
@@ -5,6 +5,7 @@ version: "3"
 services:
   jwilder-proxy:
     image: jwilder/nginx-proxy
+    hostname: pihole.yourDomain.lan
     ports:
       - '80:80'
     environment:

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -6,6 +6,7 @@ services:
   pihole:
     container_name: pihole
     image: pihole/pihole:latest
+    hostname: pihole
     # For DHCP it is recommended to remove these ports and instead add: network_mode: "host"
     ports:
       - "53:53/tcp"

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -6,7 +6,7 @@ services:
   pihole:
     container_name: pihole
     image: pihole/pihole:latest
-    hostname: pihole
+    hostname: pi.hole
     # For DHCP it is recommended to remove these ports and instead add: network_mode: "host"
     ports:
       - "53:53/tcp"


### PR DESCRIPTION
## Description
Add `hostname` to docker-compose
Note that in docker-compose-jwilder-proxy.yml example file, I used the same FQDN `pihole.yourDomain.lan` instead of just `hostname`, as used in that file for the DEFAULT_HOST environment variable (not sure if `.yourDomain.lan` should be included).

## Motivation and Context
If this is not set, the PiHole admin page shows the Docker container's ID as hostname instead.
Suggestion originally found [here](https://www.reddit.com/r/pihole/comments/gagn7p/container_hostname_for_dockerpihole/fozwt5a/). This PR addresses the next comment there ("That directive isn't in the Github notes (see https://github.com/pi-hole/docker-pi-hole)")

## How Has This Been Tested?
Tested on my own installation of PiHole, installed from the example Docker Compose file with no specific customizations.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
