### PR TITLE
Use Location: header for GitHub API call for latest tag detection.

### DIFF
--- a/gh-actions-vars.sh
+++ b/gh-actions-vars.sh
@@ -41,7 +41,7 @@ MULTIARCH_IMAGE="${BASE_IMAGE}:${GIT_TAG}"
 
 # To get latest released, cut a release on https://github.com/pi-hole/docker-pi-hole/releases (manually gated for quality control)
 latest_tag='UNKNOWN'
-if ! latest_tag=$(curl -sI https://github.com/pi-hole/docker-pi-hole/releases/latest | grep --color=never -i Location | awk -F / '{print $NF}' | tr -d '[:cntrl:]'); then
+if ! latest_tag=$(curl -sI https://github.com/pi-hole/docker-pi-hole/releases/latest | grep --color=never -i Location: | awk -F / '{print $NF}' | tr -d '[:cntrl:]'); then
     print "Failed to retrieve latest docker-pi-hole release metadata"
 else
     if [[ "${GIT_TAG}" == "${latest_tag}" ]] ; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

GitHub API added CSP with 'location' and this caused the `latest` tag to not build correctly.

Fixes #759 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
