### PR TITLE
Enable DHCP Server with environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ There are other environment variables if you want to customize various things in
 | `WEBUIBOXEDLAYOUT: <boxed\|traditional>`<br/>*Optional Default: boxed* | Use boxed layout (helpful when working on large screens)
 | `SKIPGRAVITYONBOOT`: <Not Set\|1><br/> *Optional Default: Not Set* | Use this option to skip updating the Gravity Database when booting up the container.  By default this environment variable is not set so the Gravity Database will be updated when the container starts up.  Setting this environment variable to 1 (or anything) will cause the Gravity Database to not be updated when container starts up.
 | `QUERY_LOGGING: <"true"\|"false">`<br/> *Optional* *Default: "true"* | Enable query logging or not.
+| `DHCP_ACTIVE: <"true"\|"false">`<br/> *Optional* *Default: "false"* | Enable DHCP server. Static DHCP leases can be configured with a custom `/etc/dnsmasq.d/04-pihole-static-dhcp.conf`
+| `DHCP_START: <Start IP>`<br/> *Optional* *Default: Not Set* | Start of the range of IP addresses to hand out by the DHCP server (mandatory if DHCP server is enabled).
+| `DHCP_END: <End IP>`<br/> *Optional* *Default: Not Set* | End of the range of IP addresses to hand out by the DHCP server (mandatory if DHCP server is enabled).
+| `DHCP_ROUTER: <Router's IP>`<br/> *Optional* *Default: Not Set* | Router (gateway) IP address sent by the DHCP server (mandatory if DHCP server is enabled).
+| `DHCP_LEASETIME: <hours>`<br/> *Optional* *Default: 24* | DHCP lease time in hours.
+| `PIHOLE_DOMAIN: <domain>`<br/> *Optional* *Default: lan* | Domain name sent by the DHCP server.
+| `DHCP_IPv6: <"true"\|"false">`<br/> *Optional* *Default: "false"* | Enable DHCP server IPv6 support (SLAAC + RA).
+| `DHCP_rapid_commit <"true"\|"false">`<br/> *Optional* *Default: "false"* | Enable DHCPv4 rapid commit (fast address assignment).
 
 ## Deprecated environment variables:
 While these may still work, they are likely to be removed in a future version. Where applicible, alternative variable names are indicated. Please review the table above for usage of the alternative variables

--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -332,3 +332,19 @@ setup_admin_email() {
       pihole -a -e "$EMAIL"
   fi
 }
+
+setup_dhcp() {
+  if [ -z "${DHCP_START}" ] || [ -z "${DHCP_END}" ] || [ -z "${DHCP_ROUTER}" ]; then
+    echo "ERROR: Won't enable DHCP server because mandatory Environment variables are missing: DHCP_START, DHCP_END and/or DHCP_ROUTER"
+    change_setting "DHCP_ACTIVE" "false"
+  else
+    change_setting "DHCP_ACTIVE" "${DHCP_ACTIVE}"
+    change_setting "DHCP_START" "${DHCP_START}"
+    change_setting "DHCP_END" "${DHCP_END}"
+    change_setting "DHCP_ROUTER" "${DHCP_ROUTER}"
+    change_setting "DHCP_LEASETIME" "${DHCP_LEASETIME}"
+    change_setting "PIHOLE_DOMAIN" "${PIHOLE_DOMAIN}"
+    change_setting "DHCP_IPv6" "${DHCP_IPv6}"
+    change_setting "DHCP_rapid_commit" "${DHCP_rapid_commit}"
+  fi
+}

--- a/start.sh
+++ b/start.sh
@@ -30,6 +30,14 @@ export ADMIN_EMAIL
 export WEBUIBOXEDLAYOUT
 export QUERY_LOGGING
 export PIHOLE_DNS_
+export DHCP_ACTIVE
+export DHCP_START
+export DHCP_END
+export DHCP_ROUTER
+export DHCP_LEASETIME
+export PIHOLE_DOMAIN
+export DHCP_IPv6
+export DHCP_rapid_commit
 
 export adlistFile='/etc/pihole/adlists.list'
 
@@ -117,6 +125,8 @@ else
       echo "Existing DNS servers detected in setupVars.conf. Leaving them alone"
     fi
 fi
+
+[[ -n "${DHCP_ACTIVE}" && ${DHCP_ACTIVE} == "true" ]] && echo "Setting DHCP server" && setup_dhcp
 
 setup_web_port "$WEB_PORT"
 setup_web_password "$WEBPASSWORD"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR allows enabling the DHCP server and setting its parameters through environment variables passed to the container.

*This is my first contribution to this repository, sorry for any mistakes.*

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/pi-hole/docker-pi-hole/issues/598

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I have built a local image with the changes and have tested a container in docker-compose with the following environment variables:

```yml
    environment:
      #[...]
      - DHCP_ACTIVE=true
      - DHCP_START=192.168.1.20
      - DHCP_END=192.168.1.251
      - DHCP_ROUTER=192.168.1.1
      - DHCP_LEASETIME=12
      - PIHOLE_DOMAIN=privatelan
      - DHCP_IPv6=false
      - DHCP_rapid_commit=true
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
