### PR TITLE
Add support for the i386 architecture

### DIFF
--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ARCH: [amd64, armhf, arm64]
+        ARCH: [amd64, armhf, arm64, i386]
         DEBIAN_VERSION: [stretch, buster, bullseye]
     env:
       ARCH: ${{matrix.ARCH}}

--- a/build.yml
+++ b/build.yml
@@ -47,3 +47,12 @@ services:
         PIHOLE_BASE: multiarch/debian-debootstrap:arm64-${DEBIAN_VERSION:-buster}-slim
         PIHOLE_ARCH: arm64
         S6_ARCH: aarch64
+  i386:
+    image: pihole:${PIHOLE_VERSION}-i386-${DEBIAN_VERSION:-buster}
+    build:
+      context: .
+      args:
+        <<: *common-args
+        PIHOLE_BASE: multiarch/debian-debootstrap:i386-${DEBIAN_VERSION:-buster}-slim
+        PIHOLE_ARCH: i386
+        S6_ARCH: x86

--- a/gh-actions-deploy.sh
+++ b/gh-actions-deploy.sh
@@ -53,6 +53,7 @@ declare -A annotate_map=(
     ["armel"]="--arch arm --variant v6" 
     ["armhf"]="--arch arm --variant v7" 
     ["arm64"]="--arch arm64 --variant v8"
+    ["i386"]="--arch 386" 
 )
 
 mkdir -p ~/.docker

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -91,7 +91,7 @@ def DockerPersist(request, persist_test_args, persist_args, persist_image, persi
 def entrypoint():
     return ''
 
-@pytest.fixture(params=['amd64', 'armhf', 'arm64', 'armel'])
+@pytest.fixture(params=['amd64', 'armhf', 'arm64', 'armel', 'i386'])
 def arch(request):
     return request.param
 


### PR DESCRIPTION
This PR adds support for the i386 architecture.

## Description
Adds a new image that is able to run on 32-bit hosts. The image is based on 32-bit versions of debian-debootstrap and S6.

## Motivation and Context
Being able to run Pi-hole through Docker on 32-bit machines. The i386 architecture is officially supported on Debian according to [Supported Operating Systems](https://docs.pi-hole.net/main/prerequisites/#supported-operating-systems).

## How Has This Been Tested?
Built and pushed the image to a private Docker Hub repo with Actions. Deployed it to an Atom N280 powered thin client with Docker Compose. Runs great.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
