### PR TITLE
Make test of IPv6 env variable case insensitive

### DIFF
--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -251,7 +251,7 @@ setup_web_password() {
 
 setup_ipv4_ipv6() {
     local ip_versions="IPv4 and IPv6"
-    if [ "$IPv6" != "True" ] ; then
+    if [ "${IPv6,,}" != "true" ] ; then
         ip_versions="IPv4"
         sed -i '/use-ipv6.pl/ d' /etc/lighttpd/lighttpd.conf
     fi;


### PR DESCRIPTION
## Description
Make the check of the environment variable IPv6 case insensitive

## Motivation and Context
The documentation describes the environment variable IPv6 as follows: 
> <"true"|"false">
> Optional Default: "true"

But the test of the variable is currently implemented as:
`if [ "$IPv6" != "True" ] ; then`

This is a case sensitive check against "True", which means using the documented value "true" will lead to a pi-hole without IPv6 support.

So I think it is best to make the check case insensitive.

## How Has This Been Tested?
Sorry, I could not set up the complete environment in reasonable time, so I tested this one line with this simple script:

    #!/bin/bash     
    source bash_functions.sh
    
    echo ">Expect IPv4 and IPv6"
    IPv6=true
    setup_ipv4_ipv6
    
    IPv6=True
    setup_ipv4_ipv6
    
    IPv6=TRUE
    setup_ipv4_ipv6
    
    IPv6=TruE
    setup_ipv4_ipv6
    
    echo ""
    echo ">Expect IPv4 only"
    IPv6=nottrue
    setup_ipv4_ipv6
    
    IPv6=false
    setup_ipv4_ipv6
    
    IPv6=False
    setup_ipv4_ipv6
    
    unset IPv6
    setup_ipv4_ipv6



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
