### PR TITLE
Issue #824 - Don't log password

### DIFF
--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -230,17 +230,14 @@ setup_web_password() {
     setup_var_exists "WEBPASSWORD" && return
 
     PASS="$1"
-    # Turn bash debug on while setting up password (to print it)
+    # Explicitly turn off bash printing when working with secrets
+    { set +x; } 2>/dev/null
+
     if [[ "$PASS" == "" ]] ; then
         echo "" | pihole -a -p
     else
-        echo "Setting password: ${PASS}"
-        set -x
         pihole -a -p "$PASS" "$PASS"
     fi
-    # Turn bash debug back off after print password setup
-    # (subshell to null hides printing output)
-    { set +x; } 2>/dev/null
 
     # To avoid printing this if conditional in bash debug, turn off  debug above..
     # then re-enable debug if necessary (more code but cleaner printed output)


### PR DESCRIPTION
When setting the password, explicitly disable bash logging. Leave the
re-enable code so that other functions work as expected. Additionally,
do not remove the print in generate_password so randomly generated
passwords are still logged for user consistency.

## Description
I moved the `set +x 2>/dev/null` from below the password setup to above it to disable bash debug. I also removed the explicit echo of the password. The generate_password function still contains the expected echo line for the generated password value.

## Motivation and Context
Generally, passwords should not be logged. The only time that's appropriate is when the system is generating the password for the user.

## How Has This Been Tested?
I ran the included tests, as well as testing the resulting image in my development environment. 

## Types of changes
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
