### PR TITLE
Feature: add debian bullseye

### DIFF
--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         ARCH: [amd64, armhf, arm64]
-        DEBIAN_VERSION: [stretch, buster]
+        DEBIAN_VERSION: [stretch, buster, bullseye]
     env:
       ARCH: ${{matrix.ARCH}}
       DEBIAN_VERSION: ${{matrix.DEBIAN_VERSION}}

--- a/Dockerfile.py
+++ b/Dockerfile.py
@@ -10,7 +10,7 @@ Options:
     --fail-fast          Exit on first build error
     --hub_tag=<tag>      What the Docker Hub Image should be tagged as [default: None]
     --arch=<arch>        What Architecture(s) to build     [default: amd64 armel armhf arm64]
-    --debian=<version>   What debian version(s) to build   [default: stretch buster]
+    --debian=<version>   What debian version(s) to build   [default: stretch buster bullseye]
     -v                   Print docker's command output     [default: False]
     -t                   Print docker's build time         [default: False]
 


### PR DESCRIPTION
Adding the new 'bullseye' Debian flavor - which is now in 'Hard Freeze' status. This isn't an important change, but every time there is a new Debian release, there is an influx of people wanting the newest version. If we have something already available, then it might be useful for testing before it eventually becomes the default version.

## Description

Just added Bullseye.

## Motivation and Context

Be available for testing by people who care about those things.

## How Has This Been Tested?

The first test is to see if Github Actions can build it or not.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
