### PR TITLE
Check for validity of values passed in through `PIHOLE_DNS_`

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -100,8 +100,12 @@ if [ -n "${PIHOLE_DNS_}" ]; then
     PIHOLE_DNS_ARR=(${PIHOLE_DNS_//;/ })
     count=1
     for i in "${PIHOLE_DNS_ARR[@]}"; do
-        change_setting "PIHOLE_DNS_$count" "$i"
-        ((count=count+1))
+        if valid_ip "$i" || valid_ip6 "$i" ; then
+          change_setting "PIHOLE_DNS_$count" "$i"
+          ((count=count+1))
+        else
+          echo "Invalid IP detected in PIHOLE_DNS_: ${i}"
+        fi
     done
 else
     # Environment variable has not been set, but there may be existing values in an existing setupVars.conf

--- a/start.sh
+++ b/start.sh
@@ -99,14 +99,21 @@ if [ -n "${PIHOLE_DNS_}" ]; then
     # Split into an array (delimited by ;)
     PIHOLE_DNS_ARR=(${PIHOLE_DNS_//;/ })
     count=1
+    valid_entries=0
     for i in "${PIHOLE_DNS_ARR[@]}"; do
         if valid_ip "$i" || valid_ip6 "$i" ; then
           change_setting "PIHOLE_DNS_$count" "$i"
           ((count=count+1))
+          ((valid_entries=valid_entries+1))
         else
           echo "Invalid IP detected in PIHOLE_DNS_: ${i}"
         fi
     done
+
+    if [ $valid_entries -eq 0 ]; then
+      echo "No Valid IPs dectected in PIHOLE_DNS_. Aborting"
+      exit 1
+    fi
 else
     # Environment variable has not been set, but there may be existing values in an existing setupVars.conf
     # if this is the case, we do not want to overwrite these with the defaults of 8.8.8.8 and 8.8.4.4


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a check using the already sourced `valid_ip` and `valid_ip6` functions from `basic-install.sh` to ensure that any duff values passed in through `PIHOLE_DNS_` are junked 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

See discussion here: https://github.com/pi-hole/docker-pi-hole/issues/838

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Built it, tried it:
![image](https://user-images.githubusercontent.com/1998970/115087998-33f1bc80-9f07-11eb-92e2-2fd8da08e0cc.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
