### PR TITLE
Add note regarding changing Pi-hole DNS setting when using docker bridge networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ services:
     restart: unless-stopped
 ```
 2. Run `docker-compose up --detach` to build and start pi-hole
+3. Use the Pi-hole web UI to change the DNS settings *Interface listening behavior* to "Listen on all interfaces, permit all origins", if using Docker's default `bridge` network setting
 
 [Here is an equivalent docker run script](https://github.com/pi-hole/docker-pi-hole/blob/master/docker_run.sh).
 
@@ -160,6 +161,7 @@ Here is a rundown of other arguments for your docker-compose / docker run.
   * Ubuntu users see below for more detailed information
 * You can map other ports to Pi-hole port 80 using docker's port forwarding like this `-p 8080:80` if you are using the default blocking mode. If you are using the legacy IP blocking mode, you should not remap this port.
   * [Here is an example of running with jwilder/proxy](https://github.com/pi-hole/docker-pi-hole/blob/master/docker-compose-jwilder-proxy.yml) (an nginx auto-configuring docker reverse proxy for docker) on my port 80 with Pi-hole on another port.  Pi-hole needs to be `DEFAULT_HOST` env in jwilder/proxy and you need to set the matching `VIRTUAL_HOST` for the Pi-hole's container.  Please read jwilder/proxy readme for more info if you have trouble.
+* Docker's default network mode `bridge` isolates the container from the host's network. This is a more secure setting, but requires setting the Pi-hole DNS option for *Interface listening behavior* to "Listen on all interfaces, permit all origins".
 
 ### Installing on Ubuntu
 Modern releases of Ubuntu (17.10+) include [`systemd-resolved`](http://manpages.ubuntu.com/manpages/bionic/man8/systemd-resolved.service.8.html) which is configured by default to implement a caching DNS stub resolver. This will prevent pi-hole from listening on port 53.


### PR DESCRIPTION
## Description
If using the docker default networking mode `bridge`, as suggested [here](https://docs.pi-hole.net/docker/DHCP/), it is mandatory to set the Pi-Hole DNS configuration option *Interface listening behavior* to "Listen on all interfaces, permit all origins". This change attempts to add this information to the readme file in two locations, to prevent anyone else from wasting time being unable to query the Pi-hole DNS server from another machine.

## Motivation and Context
This is a documentation change to try to eliminate user frustration in the most common use case (docker default networking)

## How Has This Been Tested?
This change only affects the top-level README.md file and does not affect the software itself.

## Types of changes
This is just a documentation fix.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

I am very open to suggestions and improvements to these small documentation changes.