### PR TITLE
Add CORS_HOSTS to PHP environment

### DIFF
--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -199,19 +199,22 @@ setup_php_env() {
       VIRTUAL_HOST="$ServerIP"
     fi;
     local vhost_line="\t\t\t\"VIRTUAL_HOST\" => \"${VIRTUAL_HOST}\","
+    local corshosts_line="\t\t\t\"CORS_HOSTS\" => \"${CORS_HOSTS}\","
     local serverip_line="\t\t\t\"ServerIP\" => \"${ServerIP}\","
     local php_error_line="\t\t\t\"PHP_ERROR_LOG\" => \"${PHP_ERROR_LOG}\","
 
     # idempotent line additions
     grep -qP "$vhost_line" "$PHP_ENV_CONFIG" || \
         sed -i "/bin-environment/ a\\${vhost_line}" "$PHP_ENV_CONFIG"
+    grep -qP "$corshosts_line" "$PHP_ENV_CONFIG" || \
+        sed -i "/bin-environment/ a\\${corshosts_line}" "$PHP_ENV_CONFIG"
     grep -qP "$serverip_line" "$PHP_ENV_CONFIG" || \
         sed -i "/bin-environment/ a\\${serverip_line}" "$PHP_ENV_CONFIG"
     grep -qP "$php_error_line" "$PHP_ENV_CONFIG" || \
         sed -i "/bin-environment/ a\\${php_error_line}" "$PHP_ENV_CONFIG"
 
     echo "Added ENV to php:"
-    grep -E '(VIRTUAL_HOST|ServerIP|PHP_ERROR_LOG)' "$PHP_ENV_CONFIG"
+    grep -E '(VIRTUAL_HOST|CORS_HOSTS|ServerIP|PHP_ERROR_LOG)' "$PHP_ENV_CONFIG"
 }
 
 setup_web_port() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This makes it possible to enables CORS per domain. 

## Description
<!--- Describe your changes in detail -->
Adds a new environment variable CORS_HOSTS which is a list of comma separated domains to PHP.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/pi-hole/docker-pi-hole/issues/864
https://github.com/bastienwirtz/homer/issues/194
Works along with https://github.com/pi-hole/AdminLTE/issues/1820

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Just adds another environment variable, that is used by auth.php (changes will be submitted as a PR)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] My code follows the code style of this project.
- [ X ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Documentation change would be to showcase the new env var and its usage. I am not sure where all the changes need to be made.

Usage is adding the below to docker-compose environment or docker run -e

`CORS_HOSTS=test.domain.com,example.com` 
