### PR TITLE
add cloudflared for doh in pihole docker setup

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -30,13 +30,25 @@ fetch_release_metadata() {
 }
 
 apt-get update
-apt-get install --no-install-recommends -y curl procps ca-certificates git
+apt-get install --no-install-recommends -y curl procps ca-certificates git gnupg2
+
 # curl in armhf-buster's image has SSL issues. Running c_rehash fixes it.
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=923479
 c_rehash
 ln -s `which echo` /usr/local/bin/whiptail
 curl -L -s $S6OVERLAY_RELEASE | tar xvzf - -C /
 mv /init /s6-init
+
+# Download cloudflared
+export ARCH_TYPE="$(uname -m)"
+if [[ "$ARCH_TYPE" == *"arm64"* ]] ; then
+curl -L -o /sbin/cloudflared https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-arm64
+elif [[ "$ARCH_TYPE" == *"arm"* ]] ; then
+curl -L -o /sbin/cloudflared https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-armv6
+else
+curl -L -o /sbin/cloudflared https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64
+fi
+chmod u+x /sbin/cloudflared
 
 # debconf-apt-progress seems to hang so get rid of it too
 which debconf-apt-progress

--- a/s6/debian-root/etc/services.d/cloudflared/finish
+++ b/s6/debian-root/etc/services.d/cloudflared/finish
@@ -1,0 +1,4 @@
+#!/usr/bin/with-contenv bash
+
+s6-echo "Stopping cloudflared proxy"
+killall -9 cloudflared

--- a/s6/debian-root/etc/services.d/cloudflared/run
+++ b/s6/debian-root/etc/services.d/cloudflared/run
@@ -1,0 +1,4 @@
+#!/usr/bin/with-contenv bash
+
+s6-echo "Starting cloudflared dns proxy"
+/sbin/cloudflared proxy-dns --port 5533


### PR DESCRIPTION
add cloudflared for doh in pihole docker setup

## Description
I was trying to add the cloudflared as a DOH lookup into the existing container

## Motivation and Context
pihole docker container is using plaintext DNS at the moment which is not ideal, user can change the pihole DNS server to 127.0.0.1#5533 if they would like to use DOH

## How Has This Been Tested?
- docker build in x86_64, pi 3b 
```
'sudo docker exec -ti pi-hole-cloudflared dig @127.0.0.1 -p5533 archlinux.org'

; <<>> DiG 9.11.5-P4-5.1+deb10u5-Debian <<>> @127.0.0.1 -p5533 archlinux.org
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 220
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;archlinux.org.                 IN      A

;; ANSWER SECTION:
archlinux.org.          3600    IN      A       95.217.163.246

;; Query time: 202 msec
;; SERVER: 127.0.0.1#5533(127.0.0.1)
;; WHEN: Sun Jun 27 07:16:12 CDT 2021
;; MSG SIZE  rcvd: 71
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
