### PR TITLE
Enable Debian Bullseye (11) images

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         ARCH: [amd64, armhf, arm64, i386]
-        DEBIAN_VERSION: [stretch, buster]
+        DEBIAN_VERSION: [stretch, buster, bullseye]
     env:
       ARCH: ${{matrix.ARCH}}
       DEBIAN_VERSION: ${{matrix.DEBIAN_VERSION}}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -11,6 +11,8 @@ jobs:
       matrix:
         ARCH: [amd64, armhf, arm64, i386]
         DEBIAN_VERSION: [stretch, buster, bullseye]
+        exclude:
+          - {ARCH: arm64, DEBIAN_VERSION: bullseye}
     env:
       ARCH: ${{matrix.ARCH}}
       DEBIAN_VERSION: ${{matrix.DEBIAN_VERSION}}

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -22,6 +22,8 @@ jobs:
       matrix:
         ARCH: [amd64, armhf, arm64, i386]
         DEBIAN_VERSION: [stretch, buster, bullseye]
+        exclude:
+          - {ARCH: arm64, DEBIAN_VERSION: bullseye}
     env:
       ARCH: ${{matrix.ARCH}}
       DEBIAN_VERSION: ${{matrix.DEBIAN_VERSION}}

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         ARCH: [amd64, armhf, arm64, i386]
-        DEBIAN_VERSION: [stretch, buster]
+        DEBIAN_VERSION: [stretch, buster, bullseye]
     env:
       ARCH: ${{matrix.ARCH}}
       DEBIAN_VERSION: ${{matrix.DEBIAN_VERSION}}

--- a/.github/workflows/workflow_dispatch.yml
+++ b/.github/workflows/workflow_dispatch.yml
@@ -23,6 +23,8 @@ jobs:
       matrix:
         ARCH: [amd64, armhf, arm64, i386]
         DEBIAN_VERSION: [stretch, buster, bullseye]
+        exclude:
+          - {ARCH: arm64, DEBIAN_VERSION: bullseye}
     env:
       ARCH: ${{matrix.ARCH}}
       DEBIAN_VERSION: ${{matrix.DEBIAN_VERSION}}

--- a/.github/workflows/workflow_dispatch.yml
+++ b/.github/workflows/workflow_dispatch.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         ARCH: [amd64, armhf, arm64, i386]
-        DEBIAN_VERSION: [stretch, buster]
+        DEBIAN_VERSION: [stretch, buster, bullseye]
     env:
       ARCH: ${{matrix.ARCH}}
       DEBIAN_VERSION: ${{matrix.DEBIAN_VERSION}}

--- a/README.md
+++ b/README.md
@@ -88,55 +88,69 @@ There are multiple different ways to run DHCP from within your Docker Pi-hole co
 ## Environment Variables
 
 There are other environment variables if you want to customize various things inside the docker container:
+### Recommended Variables
 
-| Docker Environment Var. | Description |
-| ----------------------- | ----------- |
-| `ADMIN_EMAIL: <email address>`<br/> *Optional Default: ''* | Set an administrative contact address for the Block Page
-| `TZ: <Timezone>`<br/> **Recommended** *Default: UTC* | Set your [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) to make sure logs rotate at local midnight instead of at UTC midnight.
-| `WEBPASSWORD: <Admin password>`<br/> **Recommended** *Default: random* | http://pi.hole/admin password. Run `docker logs pihole \| grep random` to find your random pass.
-| `PIHOLE_DNS_: <IPs delimited by ;>`<br/> *Optional* *Default: 8.8.8.8;8.8.4.4* | Upstream DNS server(s) for Pi-hole to forward queries to, seperated by a semicolon <br/> (supports non-standard ports with `#[port number]`) e.g `127.0.0.1#5053;8.8.8.8;8.8.4.4`
-| `DNSSEC: <"true"\|"false">`<br/> *Optional* *Default: "false"* | Enable DNSSEC support
-| `DNS_BOGUS_PRIV: <"true"\|"false">`<br/> *Optional* *Default: "true"* | Enable forwarding of reverse lookups for private ranges
-| `DNS_FQDN_REQUIRED: <"true"\|"false">`<br/> *Optional* *Default: true* | Never forward non-FQDNs
-| `REV_SERVER: <"true"\|"false">`<br/> *Optional* *Default: "false"* | Enable DNS conditional forwarding for device name resolution
-| `REV_SERVER_DOMAIN: <Network Domain>`<br/> *Optional* | If conditional forwarding is enabled, set the domain of the local network router
-| `REV_SERVER_TARGET: <Router's IP>`<br/> *Optional* | If conditional forwarding is enabled, set the IP of the local network router
-| `REV_SERVER_CIDR: <Reverse DNS>`<br/> *Optional* | If conditional forwarding is enabled, set the reverse DNS zone (e.g. `192.168.0.0/24`)
-| `ServerIP: <Host's IP>`<br/> **Recommended** | **--net=host mode requires** Set to your server's LAN IP, used by web block modes and lighttpd bind address
-| `ServerIPv6: <Host's IPv6>`<br/> *Required if using IPv6* | **If you have a v6 network** set to your server's LAN IPv6 to block IPv6 ads fully
-| `VIRTUAL_HOST: <Custom Hostname>`<br/> *Optional* *Default: $ServerIP*   | What your web server 'virtual host' is, accessing admin through this Hostname/IP allows you to make changes to the whitelist / blacklists in addition to the default 'http://pi.hole/admin/' address
-| `IPv6: <"true"\|"false">`<br/> *Optional* *Default: "true"* | For unraid compatibility, strips out all the IPv6 configuration from DNS/Web services when false.
-| `INTERFACE: <NIC>`<br/> *Advanced/Optional* | The default works fine with our basic example docker run commands.  If you're trying to use DHCP with `--net host` mode then you may have to customize this or DNSMASQ_LISTENING.
-| `DNSMASQ_LISTENING: <local\|all\|single>`<br/> *Advanced/Optional* | `local` listens on all local subnets, `all` permits listening on internet origin subnets in addition to local, `single` listens only on the interface specified.
-| `WEB_PORT: <PORT>`<br/> *Advanced/Optional* | **This will break the 'webpage blocked' functionality of Pi-hole** however it may help advanced setups like those running synology or `--net=host` docker argument.  This guide explains how to restore webpage blocked functionality using a linux router DNAT rule: [Alternative Synology installation method](https://discourse.pi-hole.net/t/alternative-synology-installation-method/5454?u=diginc)
-| `CUSTOM_CACHE_SIZE: <size>`<br/> *Advanced/Optional: Default: '10000'* | Set the cache size for dnsmasq. Useful for increasing the default cache size or to set it to 0. Note that when `DNSSEC` is "true", then this setting is ignored.
-| `DNSMASQ_USER: <pihole\|root>`<br/> *Experimental Default: root* | Allows running FTLDNS as non-root.
-| `TEMPERATUREUNIT`: <c\|k\|f><br/>*Optional Default: c* | Set preferred temperature unit to `c`: Celsius, `k`: Kelvin, or `f` Fahrenheit units.
-| `WEBUIBOXEDLAYOUT: <boxed\|traditional>`<br/>*Optional Default: boxed* | Use boxed layout (helpful when working on large screens)
-| `SKIPGRAVITYONBOOT`: <Not Set\|1><br/> *Optional Default: Not Set* | Use this option to skip updating the Gravity Database when booting up the container.  By default this environment variable is not set so the Gravity Database will be updated when the container starts up.  Setting this environment variable to 1 (or anything) will cause the Gravity Database to not be updated when container starts up.
-| `QUERY_LOGGING: <"true"\|"false">`<br/> *Optional* *Default: "true"* | Enable query logging or not.
-| `DHCP_ACTIVE: <"true"\|"false">`<br/> *Optional* *Default: "false"* | Enable DHCP server. Static DHCP leases can be configured with a custom `/etc/dnsmasq.d/04-pihole-static-dhcp.conf`
-| `DHCP_START: <Start IP>`<br/> *Optional* *Default: Not Set* | Start of the range of IP addresses to hand out by the DHCP server (mandatory if DHCP server is enabled).
-| `DHCP_END: <End IP>`<br/> *Optional* *Default: Not Set* | End of the range of IP addresses to hand out by the DHCP server (mandatory if DHCP server is enabled).
-| `DHCP_ROUTER: <Router's IP>`<br/> *Optional* *Default: Not Set* | Router (gateway) IP address sent by the DHCP server (mandatory if DHCP server is enabled).
-| `DHCP_LEASETIME: <hours>`<br/> *Optional* *Default: 24* | DHCP lease time in hours.
-| `PIHOLE_DOMAIN: <domain>`<br/> *Optional* *Default: lan* | Domain name sent by the DHCP server.
-| `DHCP_IPv6: <"true"\|"false">`<br/> *Optional* *Default: "false"* | Enable DHCP server IPv6 support (SLAAC + RA).
-| `DHCP_rapid_commit <"true"\|"false">`<br/> *Optional* *Default: "false"* | Enable DHCPv4 rapid commit (fast address assignment).
-| `WEBTHEME <"default-dark"\|"default-darker"\|"default-light">`<br/> *Optional* *Default: "default-light"* | User interface theme to use.
-| `CORS_HOSTS: <FQDNs delimited by ,>`<br/> *Advanced/Optional* | List of domains/subdomains on which CORS is allowed. Wildcards are not supported. Eg: `CORS_HOSTS: domain.com,home.domain.com,www.domain.com`.
+| Variable | Default | Value | Descrption |
+| -------- | ------- | ----- | ---------- |
+| `TZ` | UTC | `<Timezone>` | Set your [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) to make sure logs rotate at local midnight instead of at UTC midnight.
+| `WEBPASSWORD` | random | `<Admin password>` | http://pi.hole/admin password. Run `docker logs pihole \| grep random` to find your random pass.
+| `ServerIP` | unset | `<Host's IP>` | Set to your server's LAN IP, used by web block modes and lighttpd bind address
+
+### Optional Variables
+
+| Variable | Default | Value | Descrption |
+| -------- | ------- | ----- | ---------- |
+| `ADMIN_EMAIL` | unset | email address | Set an administrative contact address for the Block Page |
+| `PIHOLE_DNS_` |  `8.8.8.8;8.8.4.4` | IPs delimited by `;` | Upstream DNS server(s) for Pi-hole to forward queries to, seperated by a semicolon <br/> (supports non-standard ports with `#[port number]`) e.g `127.0.0.1#5053;8.8.8.8;8.8.4.4` |
+| `DNSSEC` | `false` | `<"true"\|"false">` | Enable DNSSEC support |
+| `DNS_BOGUS_PRIV` | `true` |`<"true"\|"false">`| Enable forwarding of reverse lookups for private ranges |
+| `DNS_FQDN_REQUIRED` | `true` | `<"true"\|"false">`| Never forward non-FQDNs |
+| `REV_SERVER` | `false` | `<"true"\|"false">` | Enable DNS conditional forwarding for device name resolution |
+| `REV_SERVER_DOMAIN` | unset | Network Domain | If conditional forwarding is enabled, set the domain of the local network router |
+| `REV_SERVER_TARGET` | unset | Router's IP | If conditional forwarding is enabled, set the IP of the local network router |
+| `REV_SERVER_CIDR` | unset | Reverse DNS | If conditional forwarding is enabled, set the reverse DNS zone (e.g. `192.168.0.0/24`) |
+| `DHCP_ACTIVE` | `false` | `<"true"\|"false">` | Enable DHCP server. Static DHCP leases can be configured with a custom `/etc/dnsmasq.d/04-pihole-static-dhcp.conf`
+| `DHCP_START` | unset | `<Start IP>` | Start of the range of IP addresses to hand out by the DHCP server (mandatory if DHCP server is enabled).
+| `DHCP_END` | unset | `<End IP>` | End of the range of IP addresses to hand out by the DHCP server (mandatory if DHCP server is enabled).
+| `DHCP_ROUTER` | unset | `<Router's IP>` | Router (gateway) IP address sent by the DHCP server (mandatory if DHCP server is enabled).
+| `DHCP_LEASETIME` | 24 | `<hours>` | DHCP lease time in hours.
+| `PIHOLE_DOMAIN` | `lan` | `<domain>` | Domain name sent by the DHCP server.
+| `DHCP_IPv6` | `false` | `<"true"\|"false">` | Enable DHCP server IPv6 support (SLAAC + RA).
+| `DHCP_rapid_commit` | `false` | `<"true"\|"false">` | Enable DHCPv4 rapid commit (fast address assignment).
+| `VIRTUAL_HOST` | `$ServerIP` | `<Custom Hostname>` | What your web server 'virtual host' is, accessing admin through this Hostname/IP allows you to make changes to the whitelist / blacklists in addition to the default 'http://pi.hole/admin/' address
+| `IPv6:` | `true` | `<"true"\|"false">` | For unraid compatibility, strips out all the IPv6 configuration from DNS/Web services when false.
+| `TEMPERATUREUNIT` | `c` | `<c\|k\|f>` | Set preferred temperature unit to `c`: Celsius, `k`: Kelvin, or `f` Fahrenheit units.
+| `WEBUIBOXEDLAYOUT` | `boxed` | `<boxed\|traditional>` | Use boxed layout (helpful when working on large screens)
+| `QUERY_LOGGING` | `true` | `<"true"\|"false">` | Enable query logging or not.
+| `WEBTHEME` | `default-light` | `<"default-dark"\|"default-darker"\|"default-light">`| User interface theme to use.
+
+### Advanced Variables
+| Variable | Default | Value | Descrption |
+| -------- | ------- | ----- | ---------- |
+| `ServerIPv6` | unset| `<Host's IPv6>` | **If you have a v6 network** set to your server's LAN IPv6 to block IPv6 ads fully
+| `INTERFACE` | unset | `<NIC>` | The default works fine with our basic example docker run commands.  If you're trying to use DHCP with `--net host` mode then you may have to customize this or DNSMASQ_LISTENING.
+| `DNSMASQ_LISTENING` | unset | `<local\|all\|single>` | `local` listens on all local subnets, `all` permits listening on internet origin subnets in addition to local, `single` listens only on the interface specified.
+| `WEB_PORT` | unset | `<PORT>` | **This will break the 'webpage blocked' functionality of Pi-hole** however it may help advanced setups like those running synology or `--net=host` docker argument.  This guide explains how to restore webpage blocked functionality using a linux router DNAT rule: [Alternative Synology installation method](https://discourse.pi-hole.net/t/alternative-synology-installation-method/5454?u=diginc)
+| `SKIPGRAVITYONBOOT` | unset | `<unset\|1>` | Use this option to skip updating the Gravity Database when booting up the container.  By default this environment variable is not set so the Gravity Database will be updated when the container starts up.  Setting this environment variable to 1 (or anything) will cause the Gravity Database to not be updated when container starts up.
+| `CORS_HOSTS` | unset | `<FQDNs delimited by ,>` | List of domains/subdomains on which CORS is allowed. Wildcards are not supported. Eg: `CORS_HOSTS: domain.com,home.domain.com,www.domain.com`.
+| `CUSTOM_CACHE_SIZE` | `10000` | Number | Set the cache size for dnsmasq. Useful for increasing the default cache size or to set it to 0. Note that when `DNSSEC` is "true", then this setting is ignored.
+
+### Experimental Variables
+| Variable | Default | Value | Descrption |
+| -------- | ------- | ----- | ---------- |
+| `DNSMASQ_USER` | unset | `<pihole\|root>` | Allows running FTLDNS as non-root.
 
 ## Deprecated environment variables:
 While these may still work, they are likely to be removed in a future version. Where applicible, alternative variable names are indicated. Please review the table above for usage of the alternative variables
 
 | Docker Environment Var. | Description | Replaced By |
 | ----------------------- | ----------- | ----------- |
-| `CONDITIONAL_FORWARDING: <"true"\|"false">`<br/> *Optional* *Default: "false"* | Enable DNS conditional forwarding for device name resolution | `REV_SERVER`|
-| `CONDITIONAL_FORWARDING_IP: <Router's IP>`<br/> *Optional* | If conditional forwarding is enabled, set the IP of the local network router | `REV_SERVER_TARGET` |
-| `CONDITIONAL_FORWARDING_DOMAIN: <Network Domain>`<br/> *Optional* | If conditional forwarding is enabled, set the domain of the local network router | `REV_SERVER_DOMAIN` |
-| `CONDITIONAL_FORWARDING_REVERSE: <Reverse DNS>`<br/> *Optional* | If conditional forwarding is enabled, set the reverse DNS of the local network router (e.g. `0.168.192.in-addr.arpa`) | `REV_SERVER_CIDR` |
-| `DNS1: <IP>`<br/> *Optional* *Default: 8.8.8.8* | Primary upstream DNS provider, default is google DNS | `PIHOLE_DNS_` |
-| `DNS2: <IP>`<br/> *Optional* *Default: 8.8.4.4* | Secondary upstream DNS provider, default is google DNS, `no` if only one DNS should used | `PIHOLE_DNS_` |
+| `CONDITIONAL_FORWARDING` | Enable DNS conditional forwarding for device name resolution | `REV_SERVER`|
+| `CONDITIONAL_FORWARDING_IP` | If conditional forwarding is enabled, set the IP of the local network router | `REV_SERVER_TARGET` |
+| `CONDITIONAL_FORWARDING_DOMAIN` | If conditional forwarding is enabled, set the domain of the local network router | `REV_SERVER_DOMAIN` |
+| `CONDITIONAL_FORWARDING_REVERSE` | If conditional forwarding is enabled, set the reverse DNS of the local network router (e.g. `0.168.192.in-addr.arpa`) | `REV_SERVER_CIDR` |
+| `DNS1` | Primary upstream DNS provider, default is google DNS | `PIHOLE_DNS_` |
+| `DNS2` | Secondary upstream DNS provider, default is google DNS, `no` if only one DNS should used | `PIHOLE_DNS_` |
 
 To use these env vars in docker run format style them like: `-e DNS1=1.1.1.1`
 

--- a/build.yml
+++ b/build.yml
@@ -26,7 +26,7 @@ services:
       context: .
       args:
         <<: *common-args
-        PIHOLE_BASE: multiarch/debian-debootstrap:armel-${DEBIAN_VERSION:-buster}-slim
+        PIHOLE_BASE: pihole/debian-debootstrap:armel-${DEBIAN_VERSION:-buster}-slim
         PIHOLE_ARCH: armel
         S6_ARCH: arm
   armhf:
@@ -35,7 +35,7 @@ services:
       context: .
       args:
         <<: *common-args
-        PIHOLE_BASE: multiarch/debian-debootstrap:armhf-${DEBIAN_VERSION:-buster}-slim
+        PIHOLE_BASE: pihole/debian-debootstrap:armhf-${DEBIAN_VERSION:-buster}-slim
         PIHOLE_ARCH: arm
         S6_ARCH: arm
   arm64:
@@ -44,7 +44,7 @@ services:
       context: .
       args:
         <<: *common-args
-        PIHOLE_BASE: multiarch/debian-debootstrap:arm64-${DEBIAN_VERSION:-buster}-slim
+        PIHOLE_BASE: pihole/debian-debootstrap:arm64-${DEBIAN_VERSION:-buster}-slim
         PIHOLE_ARCH: arm64
         S6_ARCH: aarch64
   i386:
@@ -53,6 +53,6 @@ services:
       context: .
       args:
         <<: *common-args
-        PIHOLE_BASE: multiarch/debian-debootstrap:i386-${DEBIAN_VERSION:-buster}-slim
+        PIHOLE_BASE: pihole/debian-debootstrap:i386-${DEBIAN_VERSION:-buster}-slim
         PIHOLE_ARCH: i386
         S6_ARCH: x86

--- a/install.sh
+++ b/install.sh
@@ -38,10 +38,6 @@ ln -s `which echo` /usr/local/bin/whiptail
 curl -L -s $S6OVERLAY_RELEASE | tar xvzf - -C /
 mv /init /s6-init
 
-# debconf-apt-progress seems to hang so get rid of it too
-which debconf-apt-progress
-mv "$(which debconf-apt-progress)" /bin/no_debconf-apt-progress
-
 # clone the remote repos to their local destinations
 git clone "${CORE_REMOTE_REPO}" "${CORE_LOCAL_REPO}"
 fetch_release_metadata "${CORE_LOCAL_REPO}" "${CORE_VERSION}"

--- a/s6/debian-root/etc/cont-init.d/20-start.sh
+++ b/s6/debian-root/etc/cont-init.d/20-start.sh
@@ -14,7 +14,22 @@ $bashCmd /start.sh
 if [ -n "$PYTEST" ]; then
     sed -i 's/^gravity_spinup$/#gravity_spinup # DISABLED FOR PYTEST/g' "$(which gravity.sh)"
 fi
-if [ -z "$SKIPGRAVITYONBOOT" ]; then
+
+gravityDBfile="/etc/pihole/gravity.db"
+config_file="/etc/pihole/pihole-FTL.conf"
+# make a point to mention which config file we're checking, as breadcrumb to revisit if/when pihole-FTL.conf is succeeded by TOML
+echo "  Checking if custom gravity.db is set in ${config_file}"
+if [[ -f "${config_file}" ]]; then
+    gravityDBfile="$(grep --color=never -Po "^GRAVITYDB=\K.*" "${config_file}" 2> /dev/null || echo "/etc/pihole/gravity.db")"
+fi
+
+
+if [ -z "$SKIPGRAVITYONBOOT" ] || [ ! -e "${gravityDBfile}" ]; then
+    if [ -n "$SKIPGRAVITYONBOOT" ];then
+        echo "  SKIPGRAVITYONBOOT is set, however ${gravityDBfile} does not exist (Likely due to a fresh volume). This is a required file for Pi-hole to operate."
+        echo "  Ignoring SKIPGRAVITYONBOOT on this occaision."
+    fi
+
     echo '@reboot root PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole updateGravity >/var/log/pihole_updateGravity.log || cat /var/log/pihole_updateGravity.log' > /etc/cron.d/gravity-on-boot
 else
     echo "  Skipping Gravity Database Update."


### PR DESCRIPTION
## Description

Enable Debian Bullseye (11) images. This PR is blocked on upstream changes, but I wanted to go ahead and get it queued up so it is available when ready.

* Actual support: https://github.com/pi-hole/pi-hole/pull/4221
* Test-level support: https://github.com/pi-hole/pi-hole/pull/4126

Once upstream is ready, I can rebase to re-run the actions before merge.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Have Bullseye images available.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I haven't tested this since the changes are only in github actions and will be apparent on PR submission.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

We could probably reference these images in the README if we really want to, but it might be prudent to hold off on that until we're more confident in our ability to support Bullseye. At some point far in the future, we'll make the Bullseye image the 'default' version.