### PR TITLE
Remove obsolete debconf-apt-progress workaround

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -38,10 +38,6 @@ ln -s `which echo` /usr/local/bin/whiptail
 curl -L -s $S6OVERLAY_RELEASE | tar xvzf - -C /
 mv /init /s6-init
 
-# debconf-apt-progress seems to hang so get rid of it too
-which debconf-apt-progress
-mv "$(which debconf-apt-progress)" /bin/no_debconf-apt-progress
-
 # clone the remote repos to their local destinations
 git clone "${CORE_REMOTE_REPO}" "${CORE_LOCAL_REPO}"
 fetch_release_metadata "${CORE_LOCAL_REPO}" "${CORE_VERSION}"


### PR DESCRIPTION
## Description
Since https://github.com/pi-hole/pi-hole/pull/2962 `debconf-apt-progress` is not used anymore in the basic-install.sh script, making the workaround obsolete.

## Motivation and Context
I recognised this while checking for other whiptail calls to assure that https://github.com/pi-hole/pi-hole/pull/4229 won't cause any surprises elsewhere. The workaround does not cause any issues, so this is a pure cleanup step to reduce overhead and possible confusion for contributors.

## How Has This Been Tested?
Called the script, but not inside a Docker image, to be true. However, `debconf-apt-progress` is definitely not called anywhere.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Cleanup

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
