### PR TITLE
Reduce dependency from "debconf-utils" to "debconf"

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -68,7 +68,7 @@ source $setupVars
 export USER=pihole
 
 # fix permission denied to resolvconf post-inst /etc/resolv.conf moby/moby issue #1297
-apt-get -y install debconf-utils
+apt-get -y install debconf
 echo resolvconf resolvconf/linkify-resolvconf boolean false | debconf-set-selections
 
 export PIHOLE_SKIP_OS_CHECK=true


### PR DESCRIPTION
## Description
The "debconf-set-selections" command used here is part of the "debconf" package: https://packages.debian.org/buster/all/debconf/filelist
"debconf-utils" adds the "debconf-get-selections" command, which is not used here: https://packages.debian.org/buster/all/debconf-utils/filelist

## Motivation and Context
This reduces the size/disk usage of the Docker image a little.

## How Has This Been Tested?
Called script on Debian and verified that `debconf-set-selections` is part of `debconf` on all distro versions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Minor enhancement

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
