### PR TITLE
Remove no longer needed workaround for resolvconf

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -63,10 +63,6 @@ source $setupVars
 
 export USER=pihole
 
-# fix permission denied to resolvconf post-inst /etc/resolv.conf moby/moby issue #1297
-apt-get -y install debconf-utils
-echo resolvconf resolvconf/linkify-resolvconf boolean false | debconf-set-selections
-
 export PIHOLE_SKIP_OS_CHECK=true
 
 ln -s /bin/true /usr/local/bin/service


### PR DESCRIPTION
## Description
Removes a workaround added when we used to install `resolvconf`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I don't _think_ this is required any more, but I would like someone else to confirm that first. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

built and ran locally... appears to still be working.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
