### PR TITLE
Fix gravityDB check

### DIFF
--- a/s6/debian-root/etc/cont-init.d/20-start.sh
+++ b/s6/debian-root/etc/cont-init.d/20-start.sh
@@ -14,9 +14,19 @@ $bashCmd /start.sh
 if [ -n "$PYTEST" ]; then
     sed -i 's/^gravity_spinup$/#gravity_spinup # DISABLED FOR PYTEST/g' "$(which gravity.sh)"
 fi
-if [ -z "$SKIPGRAVITYONBOOT" ] || [ ! -f /etc/pihole/gravity.db ]; then
+
+gravityDBfile="/etc/pihole/gravity.db"
+config_file="/etc/pihole/pihole-FTL.conf"
+# make a point to mention which config file we're checking, as breadcrumb to revisit if/when pihole-FTL.conf is succeeded by TOML
+echo "  Checking if custom gravity.db is set in ${config_file}"
+if [[ -f "${config_file}" ]]; then
+    gravityDBfile="$(grep --color=never -Po "^GRAVITYDB=\K.*" "${config_file}" 2> /dev/null || echo "/etc/pihole/gravity.db")"
+fi
+
+
+if [ -z "$SKIPGRAVITYONBOOT" ] || [ ! -e "${gravityDBfile}" ]; then
     if [ -n "$SKIPGRAVITYONBOOT" ];then
-        echo "  SKIPGRAVITYONBOOT is set, however no gravity.db exists (Likely due to a fresh volume). This is a required file for Pi-hole to operate."
+        echo "  SKIPGRAVITYONBOOT is set, however ${gravityDBfile} does not exist (Likely due to a fresh volume). This is a required file for Pi-hole to operate."
         echo "  Ignoring SKIPGRAVITYONBOOT on this occaision."
     fi
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Duplicate check performed in pi-hole/pi-hole/gravity.sh
pihole-FTL.conf exposes config to relocate gravityDB; it should
be sourced to determine where to check for gravityDBs existence

Signed-off-by: D.Rect <48034372+DistractionRectangle@users.noreply.github.com>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes: #878 
Follow up to: #881 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

docker-compose up with empty volume,
![00_gravitydb_not_initialized](https://user-images.githubusercontent.com/48034372/126805716-ba6ace38-03b7-43e4-b140-e7a20df1a945.png)
docker-compose down and docker-compose up (persisting volume)
![01_gravity_initialized](https://user-images.githubusercontent.com/48034372/126805775-ea0d37e9-50f7-4f6a-9fb0-247883e4c367.png)

Using interactive bash shell in running container, move gravity.db with: 
`echo "GRAVITYDB=/etc/pihole/I_moved_gravity.db" > /etc/pihole/pihole-FTL.conf`

Followed by docker-compose down and docker-compose up (persisting volumes):
![02_moved_gravity](https://user-images.githubusercontent.com/48034372/126806060-0a385fc0-d948-4a95-8497-029b35959dbf.png)

And one more time to see if gravity check finds the db at the new location and skips gravity:
![03_moved_gravity](https://user-images.githubusercontent.com/48034372/126806260-ca66aa2c-c11f-4f28-a03b-89a3e2187f85.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
