### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ services:
       - NET_ADMIN
     restart: unless-stopped
 ```
-2. Run `docker-compose up --detach` to build and start pi-hole
+2. Run `docker-compose up -d` to build and start pi-hole
 
 [Here is an equivalent docker run script](https://github.com/pi-hole/docker-pi-hole/blob/master/docker_run.sh).
 


### PR DESCRIPTION
Small correction in the 'Quick Start' section of the README

## Description
No longer suggesting the usage of the '--detatched' flag as it does not work in certain versions of docker-compose (e.g. 1.17.1, the one included in the ubuntu repos).
Now suggesting the '-d' flag, which should work with every version.

## Motivation and Context
This is a very small change but I believe having a working 'Quick start' section is very important.
