### PR TITLE
Small correction in the 'Quick Start' section of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ services:
       - NET_ADMIN
     restart: unless-stopped
 ```
-2. Run `docker-compose up --detach` to build and start pi-hole
+2. Run `docker-compose up -d` to build and start pi-hole
 3. Use the Pi-hole web UI to change the DNS settings *Interface listening behavior* to "Listen on all interfaces, permit all origins", if using Docker's default `bridge` network setting
 
 [Here is an equivalent docker run script](https://github.com/pi-hole/docker-pi-hole/blob/master/docker_run.sh).


### PR DESCRIPTION
## Description

No longer suggesting the usage of the '--detatched' flag as it does not work in certain versions of docker-compose (e.g. 1.17.1, the one included in the Ubuntu repos).  
Now suggesting the '-d' flag, which should work with every version.

## Motivation and Context

This is a very small change but I believe having a working 'Quick start' section is very important.