### PR TITLE
Remove Unneccessary kill -9

### DIFF
--- a/s6/debian-root/etc/cont-init.d/20-start.sh
+++ b/s6/debian-root/etc/cont-init.d/20-start.sh
@@ -7,8 +7,6 @@ if [ "${PH_VERBOSE:-0}" -gt 0 ] ; then
     bashCmd='bash -e -x'
 fi
 
-# used to start dnsmasq here for gravity to use...now that conflicts port 53
-
 $bashCmd /start.sh
 # Gotta go fast, no time for gravity
 if [ -n "$PYTEST" ]; then
@@ -25,8 +23,5 @@ else
     echo "  Skipping Gravity Database Update."
     [ ! -e /etc/cron.d/gravity-on-boot ] || rm /etc/cron.d/gravity-on-boot &>/dev/null
 fi
-
-# Kill dnsmasq because s6 won't like it if it's running when s6 services start
-kill -9 $(pgrep pihole-FTL) || true # TODO: REVISIT THIS SO AS TO NOT kill -9
 
 pihole -v


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Since `piholeFTL test` properly spins down it's no longer
necessary to kill it. He's dead Jim

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Merge #300, added `piholeFTL test` to the startup sequence to
replace dnsmasq as a dependency for validate_env and gravity.sh.
kill -9 was kept as a work around to a standing issue that
`piholeFTL test` didn't spin down on it's own. This was fixed
in pi-hole/FTL#1067, landed on Apr 14 2021 and confirmed
working, as evinced by #834 which was filed the same day it
that fix landed. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Docker up/down with clean volumes for amd64 and arm to make sure container boots up properly

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
