### PR TITLE
Dependabot manage GHA versions.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Let Dependabot manage the GitHub Actions versions.
