### PR TITLE
Add support for setting FTL RATE_LIMIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ There are other environment variables if you want to customize various things in
 | `QUERY_LOGGING` | `true` | `<"true"\|"false">` | Enable query logging or not.
 | `WEBTHEME` | `default-light` | `<"default-dark"\|"default-darker"\|"default-light">`| User interface theme to use.
 | `WEBPASSWORD_FILE`| unset | `<Docker secret path>` |Set an Admin password using [Docker secrets](https://docs.docker.com/engine/swarm/secrets/). If `WEBPASSWORD` is set, `WEBPASSWORD_FILE` is ignored. If `WEBPASSWORD` is empty, and `WEBPASSWORD_FILE` is set to a valid readable file path, then `WEBPASSWORD` will be set to the contents of `WEBPASSWORD_FILE`.
+|`RATE_LIMIT`| unset | `<rate-limit>` | The default settings for FTL's rate-limiting are to permit no more than 1000 queries in 60 seconds. Rate-limited queries are answered with a `REFUSED` reply and not further processed by FTL. |
 
 ### Advanced Variables
 | Variable | Default | Value | Description |

--- a/start.sh
+++ b/start.sh
@@ -40,6 +40,7 @@ export DHCP_IPv6
 export DHCP_rapid_commit
 export WEBTHEME
 export CUSTOM_CACHE_SIZE
+export RATE_LIMIT
 
 export adlistFile='/etc/pihole/adlists.list'
 
@@ -85,6 +86,7 @@ prepare_configs
 [ -n "${REV_SERVER_DOMAIN}" ] && change_setting "REV_SERVER_DOMAIN" "$REV_SERVER_DOMAIN"
 [ -n "${REV_SERVER_TARGET}" ] && change_setting "REV_SERVER_TARGET" "$REV_SERVER_TARGET"
 [ -n "${REV_SERVER_CIDR}" ] && change_setting "REV_SERVER_CIDR" "$REV_SERVER_CIDR"
+[ -n "${RATE_LIMIT}" ] && changeFTLsetting "RATE_LIMIT" "$RATE_LIMIT"
 
 if [ -z "$REV_SERVER" ];then
     # If the REV_SERVER* variables are set, then there is no need to add these.


### PR DESCRIPTION
## Description
Add support for setting `RATE_LIMIT` in FTL settings when provided.
https://docs.pi-hole.net/ftldns/configfile/#rate_limit

## Motivation and Context
Exposing additional FTL settings at runtime makes customization easier!
Some of my devices hit Pi-hole pretty hard when opening a lot of apps, I would like to easily adjust the FTL rate limit globally.

## How Has This Been Tested?
I've manually set this var in pihole-FTL.conf and restarted FTL to observe the new limit.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
