### PR TITLE
Customize pihole-FTL.conf with FTLCONF_ prefixed environment variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ There are other environment variables if you want to customize various things in
 | -------- | ------- | ----- | ---------- |
 | `TZ` | UTC | `<Timezone>` | Set your [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) to make sure logs rotate at local midnight instead of at UTC midnight.
 | `WEBPASSWORD` | random | `<Admin password>` | http://pi.hole/admin password. Run `docker logs pihole \| grep random` to find your random pass.
-| `ServerIP` | unset | `<Host's IP>` | Set to your server's LAN IP, used by web block modes and lighttpd bind address
+| `FTLCONF_REPLY_ADDR4` | unset | `<Host's IP>` | Set to your server's LAN IP, used by web block modes and lighttpd bind address.
 
 ### Optional Variables
 
@@ -129,14 +129,13 @@ There are other environment variables if you want to customize various things in
 ### Advanced Variables
 | Variable | Default | Value | Description |
 | -------- | ------- | ----- | ---------- |
-| `ServerIPv6` | unset| `<Host's IPv6>` | **If you have a v6 network** set to your server's LAN IPv6 to block IPv6 ads fully
 | `INTERFACE` | unset | `<NIC>` | The default works fine with our basic example docker run commands.  If you're trying to use DHCP with `--net host` mode then you may have to customize this or DNSMASQ_LISTENING.
 | `DNSMASQ_LISTENING` | unset | `<local\|all\|single>` | `local` listens on all local subnets, `all` permits listening on internet origin subnets in addition to local, `single` listens only on the interface specified.
 | `WEB_PORT` | unset | `<PORT>` | **This will break the 'webpage blocked' functionality of Pi-hole** however it may help advanced setups like those running synology or `--net=host` docker argument.  This guide explains how to restore webpage blocked functionality using a linux router DNAT rule: [Alternative Synology installation method](https://discourse.pi-hole.net/t/alternative-synology-installation-method/5454?u=diginc)
 | `SKIPGRAVITYONBOOT` | unset | `<unset\|1>` | Use this option to skip updating the Gravity Database when booting up the container.  By default this environment variable is not set so the Gravity Database will be updated when the container starts up.  Setting this environment variable to 1 (or anything) will cause the Gravity Database to not be updated when container starts up.
 | `CORS_HOSTS` | unset | `<FQDNs delimited by ,>` | List of domains/subdomains on which CORS is allowed. Wildcards are not supported. Eg: `CORS_HOSTS: domain.com,home.domain.com,www.domain.com`.
 | `CUSTOM_CACHE_SIZE` | `10000` | Number | Set the cache size for dnsmasq. Useful for increasing the default cache size or to set it to 0. Note that when `DNSSEC` is "true", then this setting is ignored.
-|`FTLCONF_[SETTING]` | unset | As per documentation | Customize pihole-FTL.conf with settings described in the [FTLDNS Configuration page](https://docs.pi-hole.net/ftldns/configfile/). For example, to customize REPLY_ADDR4, ensure you have the `FTLCONF_REPLY_ADDR4` environment variable set.
+| `FTLCONF_[SETTING]` | unset | As per documentation | Customize pihole-FTL.conf with settings described in the [FTLDNS Configuration page](https://docs.pi-hole.net/ftldns/configfile/). For example, to customize REPLY_ADDR6, ensure you have the `FTLCONF_REPLY_ADDR6` environment variable set.
 
 ### Experimental Variables
 | Variable | Default | Value | Description |
@@ -154,6 +153,8 @@ While these may still work, they are likely to be removed in a future version. W
 | `CONDITIONAL_FORWARDING_REVERSE` | If conditional forwarding is enabled, set the reverse DNS of the local network router (e.g. `0.168.192.in-addr.arpa`) | `REV_SERVER_CIDR` |
 | `DNS1` | Primary upstream DNS provider, default is google DNS | `PIHOLE_DNS_` |
 | `DNS2` | Secondary upstream DNS provider, default is google DNS, `no` if only one DNS should used | `PIHOLE_DNS_` |
+| `ServerIP` | Set to your server's LAN IP, used by web block modes and lighttpd bind address | `FTLCONF_REPLY_ADDR4` |
+| `ServerIPv6` | **If you have a v6 network** set to your server's LAN IPv6 to block IPv6 ads fully | `FTLCONF_REPLY_ADDR6` |
 
 To use these env vars in docker run format style them like: `-e DNS1=1.1.1.1`
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ There are other environment variables if you want to customize various things in
 | `SKIPGRAVITYONBOOT` | unset | `<unset\|1>` | Use this option to skip updating the Gravity Database when booting up the container.  By default this environment variable is not set so the Gravity Database will be updated when the container starts up.  Setting this environment variable to 1 (or anything) will cause the Gravity Database to not be updated when container starts up.
 | `CORS_HOSTS` | unset | `<FQDNs delimited by ,>` | List of domains/subdomains on which CORS is allowed. Wildcards are not supported. Eg: `CORS_HOSTS: domain.com,home.domain.com,www.domain.com`.
 | `CUSTOM_CACHE_SIZE` | `10000` | Number | Set the cache size for dnsmasq. Useful for increasing the default cache size or to set it to 0. Note that when `DNSSEC` is "true", then this setting is ignored.
+|`FTLCONF_[SETTING]` | unset | As per documentation | Customize pihole-FTL.conf with settings described in the [FTLDNS Configuration page](https://docs.pi-hole.net/ftldns/configfile/). For example, to customize REPLY_ADDR4, ensure you have the `FTLCONF_REPLY_ADDR4` environment variable set.
 
 ### Experimental Variables
 | Variable | Default | Value | Description |
@@ -230,7 +231,7 @@ https://hub.docker.com/r/pihole/pihole/tags/
 
 ## Upgrading, Persistence, and Customizations
 
-The standard Pi-hole customization abilities apply to this docker, but with docker twists such as using docker volume mounts to map host stored file configurations over the container defaults.  Volumes are also important to persist the configuration in case you have removed the Pi-hole container which is a typical docker upgrade pattern.
+The standard Pi-hole customization abilities apply to this docker, but with docker twists such as using docker volume mounts to map host stored file configurations over the container defaults.  However, mounting these configuration files as read-only should be avoided.  Volumes are also important to persist the configuration in case you have removed the Pi-hole container which is a typical docker upgrade pattern.
 
 ### Upgrading / Reconfiguring
 

--- a/start.sh
+++ b/start.sh
@@ -77,6 +77,8 @@ prepare_configs
 [ -n "${INSTALL_WEB_INTERFACE}" ] && change_setting "INSTALL_WEB_INTERFACE" "$INSTALL_WEB_INTERFACE"
 [ -n "${LIGHTTPD_ENABLED}" ] && change_setting "LIGHTTPD_ENABLED" "$LIGHTTPD_ENABLED"
 [ -n "${DNS_BOGUS_PRIV}" ] && change_setting "DNS_BOGUS_PRIV" "$DNS_BOGUS_PRIV"
+[ -n "${ServerIP}" ] && changeFTLsetting "REPLY_ADDR4" "$ServerIP"
+[ -n "${ServerIPv6}" ] && changeFTLsetting "REPLY_ADDR6" "$ServerIPv6"
 [ -n "${DNS_FQDN_REQUIRED}" ] && change_setting "DNS_FQDN_REQUIRED" "$DNS_FQDN_REQUIRED"
 [ -n "${DNSSEC}" ] && change_setting "DNSSEC" "$DNSSEC"
 [ -n "${REV_SERVER}" ] && change_setting "REV_SERVER" "$REV_SERVER"

--- a/start.sh
+++ b/start.sh
@@ -76,8 +76,6 @@ prepare_configs
 [ -n "${INSTALL_WEB_SERVER}" ] && change_setting "INSTALL_WEB_SERVER" "$INSTALL_WEB_SERVER"
 [ -n "${INSTALL_WEB_INTERFACE}" ] && change_setting "INSTALL_WEB_INTERFACE" "$INSTALL_WEB_INTERFACE"
 [ -n "${LIGHTTPD_ENABLED}" ] && change_setting "LIGHTTPD_ENABLED" "$LIGHTTPD_ENABLED"
-[ -n "${ServerIP}" ] && changeFTLsetting "REPLY_ADDR4" "$ServerIP"
-[ -n "${ServerIPv6}" ] && changeFTLsetting "REPLY_ADDR6" "$ServerIPv6"
 [ -n "${DNS_BOGUS_PRIV}" ] && change_setting "DNS_BOGUS_PRIV" "$DNS_BOGUS_PRIV"
 [ -n "${DNS_FQDN_REQUIRED}" ] && change_setting "DNS_FQDN_REQUIRED" "$DNS_FQDN_REQUIRED"
 [ -n "${DNSSEC}" ] && change_setting "DNSSEC" "$DNSSEC"
@@ -85,6 +83,15 @@ prepare_configs
 [ -n "${REV_SERVER_DOMAIN}" ] && change_setting "REV_SERVER_DOMAIN" "$REV_SERVER_DOMAIN"
 [ -n "${REV_SERVER_TARGET}" ] && change_setting "REV_SERVER_TARGET" "$REV_SERVER_TARGET"
 [ -n "${REV_SERVER_CIDR}" ] && change_setting "REV_SERVER_CIDR" "$REV_SERVER_CIDR"
+
+# Get all exported environment variables starting with FTLCONF_ as a prefix and call the changeFTLsetting
+# function with the environment variable's suffix as the key. This allows applying any pihole-FTL.conf
+# setting defined here: https://docs.pi-hole.net/ftldns/configfile/
+declare -px | grep FTLCONF_ | sed -E 's/declare -x FTLCONF_([^=]+)=\"(.+)\"/\1 \2/' | while read -r name value
+  do
+    echo "Applying pihole-FTL.conf setting $name=$value"
+    changeFTLsetting "$name" "$value"
+  done
 
 if [ -z "$REV_SERVER" ];then
     # If the REV_SERVER* variables are set, then there is no need to add these.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Parse all environment variables starting with the `FTLCONF_` prefix and setup the variable's suffix as a `pihole-FTL.conf` customized setting. For example, setting the `FTLCONF_REPLY_ADDR4=10.1.2.3` environment variable would result in a `pihole-FTL.conf` setting of `REPLY_ADDR4=10.1.2.3`.

~~This PR is marked as having a breaking change since the yet undocumented `ServerIP` and `ServerIPv6` variables have been deprecated in favor of provisioning them as `FTLCONF_REPLY_ADDR4` and `FTLCONF_REPLY_ADDR6` respectively.~~

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Addresses #922 and #919

There were use cases where `pihole-FTL.conf` could be supplied through a read-only filesystem i.e.: a Kubernetes ConfigMap, and calling the `changeFTLsetting` function on such a read-only file would cause the container to crash loop. This PR is meant to provide the pi-hole administrator all the flexibility that was previously associated with volume-mounting a customized `pihole-FTL.conf`, but now by using environment variables.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- `docker run -it -e FTLCONF_REPLY_ADDR4=10.1.2.3 -e FTLCONF_MAXDBDAYS=7 issue922`
- Shelled into the running container then executed:
```
# cat /etc/pihole/pihole-FTL.conf
PRIVACYLEVEL=0
MAXDBDAYS=7
REPLY_ADDR4=10.1.2.3
#
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
