### PR TITLE
Fix duplicate php env config values after upgrades and config changes

### DIFF
--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -198,23 +198,17 @@ setup_php_env() {
     if [ -z "$VIRTUAL_HOST" ] ; then
       VIRTUAL_HOST="$ServerIP"
     fi;
-    local vhost_line="\t\t\t\"VIRTUAL_HOST\" => \"${VIRTUAL_HOST}\","
-    local corshosts_line="\t\t\t\"CORS_HOSTS\" => \"${CORS_HOSTS}\","
-    local serverip_line="\t\t\t\"ServerIP\" => \"${ServerIP}\","
-    local php_error_line="\t\t\t\"PHP_ERROR_LOG\" => \"${PHP_ERROR_LOG}\","
-    local pihole_docker_tag_line="\t\t\t\"PIHOLE_DOCKER_TAG\" => \"${PIHOLE_DOCKER_TAG}\","
 
-    # idempotent line additions
-    grep -qP "$vhost_line" "$PHP_ENV_CONFIG" || \
-        sed -i "/bin-environment/ a\\${vhost_line}" "$PHP_ENV_CONFIG"
-    grep -qP "$corshosts_line" "$PHP_ENV_CONFIG" || \
-        sed -i "/bin-environment/ a\\${corshosts_line}" "$PHP_ENV_CONFIG"
-    grep -qP "$serverip_line" "$PHP_ENV_CONFIG" || \
-        sed -i "/bin-environment/ a\\${serverip_line}" "$PHP_ENV_CONFIG"
-    grep -qP "$php_error_line" "$PHP_ENV_CONFIG" || \
-        sed -i "/bin-environment/ a\\${php_error_line}" "$PHP_ENV_CONFIG"
-    grep -qP "$pihole_docker_tag_line" "$PHP_ENV_CONFIG" || \
-        sed -i "/bin-environment/ a\\${pihole_docker_tag_line}" "$PHP_ENV_CONFIG"
+    for config_var in "VIRTUAL_HOST" "CORS_HOSTS" "ServerIP" "PHP_ERROR_LOG" "PIHOLE_DOCKER_TAG"; do
+      local beginning_of_line="\t\t\t\"${config_var}\" => "
+      if grep -qP "$beginning_of_line" "$PHP_ENV_CONFIG" ; then
+        # replace line if already present
+        sed -i "/${beginning_of_line}/c\\${beginning_of_line}\"${!config_var}\"," "$PHP_ENV_CONFIG"
+      else
+        # add line otherwise
+        sed -i "/bin-environment/ a\\${beginning_of_line}\"${!config_var}\"," "$PHP_ENV_CONFIG"
+      fi
+    done
 
     echo "Added ENV to php:"
     grep -E '(VIRTUAL_HOST|CORS_HOSTS|ServerIP|PHP_ERROR_LOG|PIHOLE_DOCKER_TAG)' "$PHP_ENV_CONFIG"


### PR DESCRIPTION
## Description
I changed the behavior of setup_php_env such that it changes lines that are already present instead of adding them always to PHP_ENV_CONFIG.

## Motivation and Context
The previous behavior of setup_php_env lead to duplicate config entries upon upgrading the container image (i.e. changes to PIHOLE_DOCKER_TAG) or changes to any of the other config parameters. This has been reported in #952.

## How Has This Been Tested?
I ran setup_php_env with different php env config files and verified that the config files were OK.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
