### PR TITLE
Increase verbosity of error message when capabilities cannot be set, add note to readme about default DNSMASQ_USER.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ services:
     ports:
       - "53:53/tcp"
       - "53:53/udp"
-      - "67:67/udp"
+      - "67:67/udp" # Only required if you are using Pi-hole as your DHCP server
       - "80:80/tcp"
     environment:
       TZ: 'America/Chicago'
@@ -29,17 +29,21 @@ services:
     # Volumes store your data between container upgrades
     volumes:
       - './etc-pihole:/etc/pihole'
-      - './etc-dnsmasq.d:/etc/dnsmasq.d'
-    # Recommended but not required (DHCP needs NET_ADMIN)
+      - './etc-dnsmasq.d:/etc/dnsmasq.d'    
     #   https://github.com/pi-hole/docker-pi-hole#note-on-capabilities
     cap_add:
-      - NET_ADMIN
+      - NET_ADMIN # Recommended but not required (DHCP needs NET_ADMIN)      
     restart: unless-stopped
 ```
 2. Run `docker-compose up -d` to build and start pi-hole
 3. Use the Pi-hole web UI to change the DNS settings *Interface listening behavior* to "Listen on all interfaces, permit all origins", if using Docker's default `bridge` network setting
 
 [Here is an equivalent docker run script](https://github.com/pi-hole/docker-pi-hole/blob/master/docker_run.sh).
+
+## Upgrade Notes
+In `2022.01` and later, the default `DNSMASQ_USER` has been changed to `pihole`, however this may cause issues on some systems such as Synology, see Issue [#963](https://github.com/pi-hole/docker-pi-hole/issues/963) for more information.
+
+If the container wont start due to issues setting capabilities, set `DNSMASQ_USER` to `root` in your environment.
 
 ## Overview
 

--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -3,10 +3,11 @@
 . /opt/pihole/webpage.sh
 
 fix_capabilities() {
-    setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN,CAP_SYS_NICE,CAP_CHOWN,CAP_IPC_LOCK+ei $(which pihole-FTL) || ret=$?
+    setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN,CAP_SYS_NICE,CAP_CHOWN+ei $(which pihole-FTL) || ret=$?
 
-    if [[ $ret -ne 0 && "${DNSMASQ_USER:-root}" != "root" ]]; then
-        echo "ERROR: Failed to set capabilities for pihole-FTL. Cannot run as non-root."
+    if [[ $ret -ne 0 && "${DNSMASQ_USER:-pihole}" != "root" ]]; then
+        echo "ERROR: Unable to set capabilities for pihole-FTL. Cannot run as non-root."
+        echo "       If you are seeing this error, please set the environment variable DNSMASQ_USER=root"
         exit 1
     fi
 }


### PR DESCRIPTION
See #963 for details