### PR TITLE
Update list of available web themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ There are other environment variables if you want to customize various things in
 | `TEMPERATUREUNIT` | `c` | `<c\|k\|f>` | Set preferred temperature unit to `c`: Celsius, `k`: Kelvin, or `f` Fahrenheit units.
 | `WEBUIBOXEDLAYOUT` | `boxed` | `<boxed\|traditional>` | Use boxed layout (helpful when working on large screens)
 | `QUERY_LOGGING` | `true` | `<"true"\|"false">` | Enable query logging or not.
-| `WEBTHEME` | `default-light` | `<"default-dark"\|"default-darker"\|"default-light">`| User interface theme to use.
+| `WEBTHEME` | `default-light` | `<"default-dark"\|"default-darker"\|"default-light"\|"default-auto"\|"lcars">`| User interface theme to use.
 | `WEBPASSWORD_FILE`| unset | `<Docker secret path>` |Set an Admin password using [Docker secrets](https://docs.docker.com/engine/swarm/secrets/). If `WEBPASSWORD` is set, `WEBPASSWORD_FILE` is ignored. If `WEBPASSWORD` is empty, and `WEBPASSWORD_FILE` is set to a valid readable file path, then `WEBPASSWORD` will be set to the contents of `WEBPASSWORD_FILE`.
 
 ### Advanced Variables

--- a/start.sh
+++ b/start.sh
@@ -152,7 +152,7 @@ fi
 # If an invalid theme name was supplied, setup WEBTHEME to use the default-light theme.
 if [ -n "${WEBTHEME}" ]; then
     case "${WEBTHEME}" in
-      "default-dark" | "default-darker" | "default-light")
+      "default-dark" | "default-darker" | "default-light" | "default-auto" | "lcars")
         echo "Setting Web Theme based on WEBTHEME variable, using value ${WEBTHEME}"
         change_setting "WEBTHEME" "${WEBTHEME}"
         ;;


### PR DESCRIPTION
## Description
Update list of available web themes to the content of https://github.com/pi-hole/AdminLTE/blob/master/scripts/pi-hole/php/theme.php.

## Motivation and Context
This solves that the web theme LCARS and default-auto can not be set using the appropriate environment variable.

## How Has This Been Tested?
Starting the Docker container with the command
```docker run --rm -p 80:80 -e WEBTHEME=lcars ...```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
