### PR TITLE
Prevent logspam when restarting FTL (Error from kill command)

### DIFF
--- a/s6/debian-root/etc/services.d/pihole-FTL/finish
+++ b/s6/debian-root/etc/services.d/pihole-FTL/finish
@@ -1,4 +1,4 @@
 #!/usr/bin/with-contenv bash
 
 s6-echo "Stopping pihole-FTL"
-kill -15 $(pgrep pihole-FTL) # TODO: REVISIT THIS SO AS TO NOT kill -9
+kill -15 $(pgrep pihole-FTL)

--- a/s6/service
+++ b/s6/service
@@ -2,29 +2,49 @@
 # This script patches all service commands into the appropriate s6- commands
 # pi-hole upstream scripts need a 'service' interface. why not systemd? docker said so.
 start() {
-    s6-svc -wU -u -T2500 /var/run/s6/services/$service
+  s6-svc -wU -u -T2500 /var/run/s6/services/$service
 }
 
 stop() {
-    s6-svc -wD -d -T2500 /var/run/s6/services/$service
+  s6-svc -wD -d -T2500 /var/run/s6/services/$service
 }
 
 restart() {
+  local pid
+
+  # Get the PID of the service we are asking to restart
+  pid=$(pgrep $service)
+
+  # Only attempt to stop the service if it is already running
+  if [ -n "$pid" ]; then
     stop
+
+    # Loop until we are certain that the process has been stopped
+    while test -d /proc/$pid; do
+      sleep 0.2
+    done
+  fi
+
+  # Check it hasn't been started by something else in the meantime
+  pid=$(pgrep $service)
+  
+  # Only attempt to start the service if it is not already running
+  if [ -z "$pid" ]; then
     start
-    #s6-svc -t -wR -T5000 /var/run/s6/services/$service
+  fi
+  
 }
 
 status() {
-    s6-svstat /var/run/s6/services/$service
+  s6-svstat /var/run/s6/services/$service
 }
 
 service="$1"
 command="$2"
 
 if [[ ! -d "/var/run/s6/services/$service" ]] ; then
-    echo "s6 service not found for $service, exiting..."
-    exit
+  echo "s6 service not found for $service, exiting..."
+  exit
 fi;
 
 ${command} "${service}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Waits until the process is dead before attempting to start it again. Prevents this:

![image](https://user-images.githubusercontent.com/1998970/148617703-d82ec09b-d623-45aa-980f-23ed2504f7e6.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The logspam is annoying

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I restarted FTL within the container several times. It no longer prints the warning about the usage of `kill`

![image](https://user-images.githubusercontent.com/1998970/148617828-1ac2277c-afa8-49a4-b494-092ef6a994e1.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
