### PR TITLE
Switch base image from Buster to Bullseye

### DIFF
--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ARCH: amd64
-      DEBIAN_VERSION: buster
+      DEBIAN_VERSION: bullseye
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG PIHOLE_BASE
-FROM "${PIHOLE_BASE:-ghcr.io/pi-hole/docker-pi-hole-base:buster-slim}"
+FROM "${PIHOLE_BASE:-ghcr.io/pi-hole/docker-pi-hole-base:bullseye-slim}"
 
 ARG PIHOLE_DOCKER_TAG
 ENV PIHOLE_DOCKER_TAG "${PIHOLE_DOCKER_TAG}"

--- a/build.yml
+++ b/build.yml
@@ -9,9 +9,9 @@ x-common-args: &common-args
 
 services:
   amd64:
-    image: pihole:${PIHOLE_DOCKER_TAG}-amd64-${DEBIAN_VERSION:-buster}
+    image: pihole:${PIHOLE_DOCKER_TAG}-amd64-${DEBIAN_VERSION:-bullseye}
     build:
       context: .
       args:
         <<: *common-args
-        PIHOLE_BASE: ghcr.io/pi-hole/docker-pi-hole-base:${DEBIAN_VERSION:-buster}-slim
+        PIHOLE_BASE: ghcr.io/pi-hole/docker-pi-hole-base:${DEBIAN_VERSION:-bullseye}-slim

--- a/install.sh
+++ b/install.sh
@@ -26,11 +26,6 @@ esac
   echo "https://github.com/just-containers/s6-overlay/releases/download/${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.gz"
 }
 
-apt-get update
-apt-get install --no-install-recommends -y curl procps ca-certificates git
-# curl in armhf-buster's image has SSL issues. Running c_rehash fixes it.
-# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=923479
-c_rehash
 ln -s `which echo` /usr/local/bin/whiptail
 curl -L -s "$(s6_download_url)" | tar xvzf - -C /
 mv /init /s6-init


### PR DESCRIPTION
## Description

Update base image to use Bullesye instead of Buster.

## Motivation and Context

Bullesye has been out for a few months now, and as it is the latest version of Debian we [officially support](https://docs.pi-hole.net/main/prerequisites/), it makes sense for the official docker container to be on the same OS.

## How Has This Been Tested?

Built locally and tested. I've also removed a fix that was added to fix an issue with curl in armhf-buster. Appears to be sorted in Bullseye, tested as follows from Docker on Windows:

Broken:
```
docker run -it --rm arm32v7/debian:buster  \
      /bin/bash -c \
        'export DEBIAN_FRONTEND=noninteractive && \
        apt-get update &&  apt-get install -y ca-certificates curl && \
        curl -sSL https://www.google.com'
```

Working:
```
docker run -it --rm arm32v7/debian:bullseye  \
      /bin/bash -c \
        'export DEBIAN_FRONTEND=noninteractive && \
        apt-get update &&  apt-get install -y ca-certificates curl && \
        curl -sSL https://www.google.com'
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.