### PR TITLE
Don't attempt to chmod pihole-FTL.db if it does not exist

### DIFF
--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -27,7 +27,7 @@ prepare_configs() {
     # Also  similar to preflights for FTL https://github.com/pi-hole/pi-hole/blob/master/advanced/Templates/pihole-FTL.service
     chown pihole:root /etc/lighttpd
     chown pihole:pihole "${PI_HOLE_CONFIG_DIR}/pihole-FTL.conf" "/var/log/pihole"
-    chmod 644 "${PI_HOLE_CONFIG_DIR}/pihole-FTL.conf" "${PI_HOLE_CONFIG_DIR}/pihole-FTL.db"
+    chmod 644 "${PI_HOLE_CONFIG_DIR}/pihole-FTL.conf"
     if [[ -e "${PI_HOLE_CONFIG_DIR}/pihole-FTL.db" ]]; then
       chown pihole:pihole "${PI_HOLE_CONFIG_DIR}/pihole-FTL.db"
       chmod 644 "${PI_HOLE_CONFIG_DIR}/pihole-FTL.db"


### PR DESCRIPTION
## Description

Removes a reference to pihole-FTL.db that I forgot to remove in 2567ab99406cac265db06e53a25086031b929b5d

## Motivation and Context

I like to tidy up my mistakes

## How Has This Been Tested?

N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.