### PR TITLE
If PIHOLE_DNS_ env var is employed, use that as source of truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ There are other environment variables if you want to customize various things in
 | Variable | Default | Value | Description |
 | -------- | ------- | ----- | ---------- |
 | `ADMIN_EMAIL` | unset | email address | Set an administrative contact address for the Block Page |
-| `PIHOLE_DNS_` |  `8.8.8.8;8.8.4.4` | IPs delimited by `;` | Upstream DNS server(s) for Pi-hole to forward queries to, seperated by a semicolon <br/> (supports non-standard ports with `#[port number]`) e.g `127.0.0.1#5053;8.8.8.8;8.8.4.4` |
+| `PIHOLE_DNS_` |  `8.8.8.8;8.8.4.4` | IPs delimited by `;` | Upstream DNS server(s) for Pi-hole to forward queries to, seperated by a semicolon <br/> (supports non-standard ports with `#[port number]`) e.g `127.0.0.1#5053;8.8.8.8;8.8.4.4` Note: The existence of this environment variable assumes this as the _sole_ management of upstream DNS. Upstream DNS added via the web interface will be overwritten on container restart/recreation |
 | `DNSSEC` | `false` | `<"true"\|"false">` | Enable DNSSEC support |
 | `DNS_BOGUS_PRIV` | `true` |`<"true"\|"false">`| Never forward reverse lookups for private ranges |
 | `DNS_FQDN_REQUIRED` | `true` | `<"true"\|"false">`| Never forward non-FQDNs |

--- a/start.sh
+++ b/start.sh
@@ -115,7 +115,10 @@ fi
 # Parse the PIHOLE_DNS variable, if it exists, and apply upstream servers to Pi-hole config
 if [ -n "${PIHOLE_DNS_}" ]; then
     echo "Setting DNS servers based on PIHOLE_DNS_ variable"
+    # Remove any PIHOLE_DNS_ entries from setupVars.conf, if they exist
+    sed -i '/PIHOLE_DNS_/d' setupVars.conf
     # Split into an array (delimited by ;)
+    # Loop through and add them one by one to setupVars.conf
     PIHOLE_DNS_ARR=(${PIHOLE_DNS_//;/ })
     count=1
     valid_entries=0


### PR DESCRIPTION
## Description

With this change:
 - If `PIHOLE_DNS_` env var is NOT set:
   -  If it's brand new and no setupVars.conf exists - defaults of `8.8.8.8` and `8.8.4.4` are used (no change in behaviour)
   -  If `setupVars.conf` exists, and already contains `PIHOLE_DNS_n` settings, then it will not be touched (no change in behaviour)
- If `PIHOLE_DNS_` env var IS set:
  - All `PIHOLE_DNS_n` settings are removed on each container start/create, and those passed in via the env var are applied

## Motivation and Context

Addresses concerns raised in https://github.com/pi-hole/docker-pi-hole/issues/929

Currently if one was to use the env var to control this setting, and went from having two upstream servers, down to one - the second value would remain in place.

This PR prevents that from happening by effectively starting this setting application from scratch each time

## How Has This Been Tested?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) 

Only _kind of_ a breaking change - but it fixes unintended behaviour.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.