### PR TITLE
Fix first start up "pihole-FTL.db" not exist error

### DIFF
--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -27,7 +27,7 @@ prepare_configs() {
     # Also  similar to preflights for FTL https://github.com/pi-hole/pi-hole/blob/master/advanced/Templates/pihole-FTL.service
     chown pihole:root /etc/lighttpd
     chown pihole:pihole "${PI_HOLE_CONFIG_DIR}/pihole-FTL.conf" "/var/log/pihole"
-    chmod 644 "${PI_HOLE_CONFIG_DIR}/pihole-FTL.conf" "${PI_HOLE_CONFIG_DIR}/pihole-FTL.db"
+    chmod 644 "${PI_HOLE_CONFIG_DIR}/pihole-FTL.conf"
     if [[ -e "${PI_HOLE_CONFIG_DIR}/pihole-FTL.db" ]]; then
       chown pihole:pihole "${PI_HOLE_CONFIG_DIR}/pihole-FTL.db"
       chmod 644 "${PI_HOLE_CONFIG_DIR}/pihole-FTL.db"


### PR DESCRIPTION
## Description

Use docker logs to see to log from the first start, there's an error: chmod: cannot access '/etc/pihole/pihole-FTL.db': No such file or directory

Actually, `${PI_HOLE_CONFIG_DIR}/pihole-FTL.db` will be checked just a     few lines later, and only to change the mode on it if it exists. So it should be removed from the upper `chmod 644` command.

## Motivation and Context

Fix #984

## How Has This Been Tested?

This change looks very trivial to the bug, and the diff and the error message explains good enough. so I didn't prepare a test for it.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
