### PR TITLE
Use consistent method to kill process in s6 finish script

### DIFF
--- a/s6/debian-root/etc/services.d/pihole-FTL/finish
+++ b/s6/debian-root/etc/services.d/pihole-FTL/finish
@@ -1,4 +1,4 @@
 #!/usr/bin/with-contenv bash
 
 s6-echo "Stopping pihole-FTL"
-kill -15 $(pgrep pihole-FTL)
+killall -15 pihole-FTL


### PR DESCRIPTION
## Description

If the process does not exist, the error message of `kill` command is a little bit confusing:

`kill: usage: kill [-s sigspec | -n signum | -sigspec] pid | jobspec ... or kill -l [sigspec]`

Using `killall` in `/s6/debian-root/etc/services.d/pihole-FTL/finish` to kill the process, like what we do in `cron/finish` & `lighttpd/finish`, will make the usage in this project more consistent, and also, the command `killall` will provide better & friendly output, like:

`pihole-FTL: no process found`

Close #986, cc #973

## Motivation and Context

Consistent usage in the same project and user understandable/friendly output is important ;)

## How Has This Been Tested?

I manually applied the patch in the Pi-Hole container I'm running to verify the refult ;)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
