### PR TITLE
Touch/chown lighttpd access/error logs on service start

### DIFF
--- a/s6/debian-root/etc/services.d/lighttpd/run
+++ b/s6/debian-root/etc/services.d/lighttpd/run
@@ -1,4 +1,12 @@
 #!/usr/bin/with-contenv bash
 
 s6-echo "Starting lighttpd"
+
+# Touch log files to ensure they exist (create if non-existing, preserve if existing)
+touch /var/log/lighttpd/access.log /var/log/lighttpd/error.log
+
+# Ensure that permissions are set so that lighttpd can write to the logs
+chown www-data:www-data /var/log/lighttpd/access.log /var/log/lighttpd/error.log
+chmod 0644 /var/log/lighttpd/access.log /var/log/lighttpd/error.log
+
 lighttpd -D -f /etc/lighttpd/lighttpd.conf


### PR DESCRIPTION
## Description

Playing about with some alternatives to https://github.com/pi-hole/docker-pi-hole/pull/990, I noticed that if we didn't create FIFO pipes, but instead just `tail -f` existing log files, they need to actually exist first...

## Motivation and Context

## How Has This Been Tested?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.