### PR TITLE
Dev origin: enable lighttpd-mod-ssl in lighttpd when based on debian:bullseye

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -69,6 +69,12 @@ sed -i $'s/)\s*uninstallFunc/) unsupportedFunc/g' /usr/local/bin/pihole
 # pihole -r / pihole reconfigure
 sed -i $'s/)\s*reconfigurePiholeFunc/) unsupportedFunc/g' /usr/local/bin/pihole
 
+#enable ssl mod ssl if needed (debian:billseye)
+if [ -z "$(compgen -G /etc/lighttpd/conf-enabled/*-ssl.conf)" ]; then
+  apt-get update && apt-get install -y --no-install-recommends lighttpd-mod-openssl
+  lighty-enable-mod ssl
+fi
+
 if [[ "${PIHOLE_DOCKER_TAG}" != "dev" && "${PIHOLE_DOCKER_TAG}" != "nightly" ]]; then
   # If we are on a version other than dev or nightly, disable `pihole checkout`, otherwise it is useful to have for quick troubleshooting sometimes
   sed -i $'s/)\s*piholeCheckoutFunc/) unsupportedFunc/g' /usr/local/bin/pihole

--- a/s6/debian-root/etc/cont-init.d/20-start.sh
+++ b/s6/debian-root/etc/cont-init.d/20-start.sh
@@ -36,4 +36,13 @@ fi
 
 pihole -v
 
+# generate default certificate if needed
+if [ ! -e /etc/lighttpd/server.pem ]; then
+  echo "Generating a ssl certificate for lighttpd."
+  openssl req -x509 -newkey rsa:4096 -nodes -keyout /etc/lighttpd/key.pem -out /etc/lighttpd/certificate.pem -sha256 -days 3650 -subj "/C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=www.example.com"
+  cat /etc/lighttpd/certificate.pem /etc/lighttpd/key.pem > /etc/lighttpd/server.pem
+  chown -R www-data:www-data /etc/lighttpd
+  chmod 0600 /etc/lighttpd/*.pem
+fi
+
 echo "  Container tag is: ${PIHOLE_DOCKER_TAG}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Enable lighttpd-mod-ssl as it's not enabled in debian:bullseye, but it was in debian:buster.
* mod is installed during image buidling.
* certificate is generated if missing at container runtime.

After merge, lighttpd will handle ssl connection to admin interface whatever is debian's version (buster/bullseye)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Restore a feature that was available on debian:buster based images.
On bullseye, lighttpd by default cannot handle ssl connections.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
* define port 1443:443 in docker-compose
* docker compose up
* opened a web browser https://localhost:1443/admin/
* Set exception to insecure certificate (self generated certificate)
* browse admin site


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
