### PR TITLE
Support docker service names and links for PIHOLE_DNS_

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ There are other environment variables if you want to customize various things in
 | Variable | Default | Value | Description |
 | -------- | ------- | ----- | ---------- |
 | `ADMIN_EMAIL` | unset | email address | Set an administrative contact address for the Block Page |
-| `PIHOLE_DNS_` |  `8.8.8.8;8.8.4.4` | IPs delimited by `;` | Upstream DNS server(s) for Pi-hole to forward queries to, seperated by a semicolon <br/> (supports non-standard ports with `#[port number]`) e.g `127.0.0.1#5053;8.8.8.8;8.8.4.4` Note: The existence of this environment variable assumes this as the _sole_ management of upstream DNS. Upstream DNS added via the web interface will be overwritten on container restart/recreation |
+| `PIHOLE_DNS_` |  `8.8.8.8;8.8.4.4` | IPs delimited by `;` | Upstream DNS server(s) for Pi-hole to forward queries to, seperated by a semicolon <br/> (supports non-standard ports with `#[port number]`) e.g `127.0.0.1#5053;8.8.8.8;8.8.4.4` <br/> (supports [Docker service names and links](https://docs.docker.com/compose/networking/) instead of IPs) e.g `upstream0;upstream1` where `upstream0` and `upstream1` are the service names of or links to docker services <br/> Note: The existence of this environment variable assumes this as the _sole_ management of upstream DNS. Upstream DNS added via the web interface will be overwritten on container restart/recreation |
 | `DNSSEC` | `false` | `<"true"\|"false">` | Enable DNSSEC support |
 | `DNS_BOGUS_PRIV` | `true` |`<"true"\|"false">`| Never forward reverse lookups for private ranges |
 | `DNS_FQDN_REQUIRED` | `true` | `<"true"\|"false">`| Never forward non-FQDNs |

--- a/start.sh
+++ b/start.sh
@@ -127,9 +127,22 @@ if [ -n "${PIHOLE_DNS_}" ]; then
           change_setting "PIHOLE_DNS_$count" "$i"
           ((count=count+1))
           ((valid_entries=valid_entries+1))
-        else
-          echo "Invalid IP detected in PIHOLE_DNS_: ${i}"
+          continue
         fi
+        if [ -n "$(dig +short $i)" ]; then
+          # If the "address" is a domain (for example a docker link) then try to resolve it and add 
+          # the result as a DNS server in setupVars.conf.
+          resolved_ip="$(dig +short $i | head -n 1)"
+          echo "Resolved ${i} from PIHOLE_DNS_ as: ${resolved_ip}"
+          if valid_ip "$resolved_ip" || valid_ip6 "$resolved_ip" ; then
+            change_setting "PIHOLE_DNS_$count" "$resolved_ip"
+            ((count=count+1))
+            ((valid_entries=valid_entries+1))
+            continue
+          fi
+        fi
+        # If the above tests fail then this is an invalid DNS server
+        echo "Invalid IP detected in PIHOLE_DNS_: ${i}"
     done
 
     if [ $valid_entries -eq 0 ]; then

--- a/start.sh
+++ b/start.sh
@@ -129,10 +129,13 @@ if [ -n "${PIHOLE_DNS_}" ]; then
           ((valid_entries=valid_entries+1))
           continue
         fi
-        if [ -n "$(dig +short $i)" ]; then
+        if [ -n "$(dig +short ${i//#*/})" ]; then
           # If the "address" is a domain (for example a docker link) then try to resolve it and add 
           # the result as a DNS server in setupVars.conf.
-          resolved_ip="$(dig +short $i | head -n 1)"
+          resolved_ip="$(dig +short ${i//#*/} | head -n 1)"
+          if [ -n "${i//*#/}" ]; then
+            resolved_ip="${resolved_ip}#${i//*#/}"
+          fi
           echo "Resolved ${i} from PIHOLE_DNS_ as: ${resolved_ip}"
           if valid_ip "$resolved_ip" || valid_ip6 "$resolved_ip" ; then
             change_setting "PIHOLE_DNS_$count" "$resolved_ip"

--- a/start.sh
+++ b/start.sh
@@ -142,11 +142,11 @@ if [ -n "${PIHOLE_DNS_}" ]; then
           fi
         fi
         # If the above tests fail then this is an invalid DNS server
-        echo "Invalid IP detected in PIHOLE_DNS_: ${i}"
+        echo "Invalid entry detected in PIHOLE_DNS_: ${i}"
     done
 
     if [ $valid_entries -eq 0 ]; then
-      echo "No Valid IPs dectected in PIHOLE_DNS_. Aborting"
+      echo "No Valid entries dectected in PIHOLE_DNS_. Aborting"
       exit 1
     fi
 else

--- a/start.sh
+++ b/start.sh
@@ -133,7 +133,7 @@ if [ -n "${PIHOLE_DNS_}" ]; then
           # If the "address" is a domain (for example a docker link) then try to resolve it and add 
           # the result as a DNS server in setupVars.conf.
           resolved_ip="$(dig +short ${i//#*/} | head -n 1)"
-          if [ -n "${i//*#/}" ]; then
+          if [ -n "${i//*#/}" ] && [ "${i//*#/}" != "${i//#*/}" ]; then
             resolved_ip="${resolved_ip}#${i//*#/}"
           fi
           echo "Resolved ${i} from PIHOLE_DNS_ as: ${resolved_ip}"


### PR DESCRIPTION
Added the ability to use docker service names or links in `PIHOLE_DNS_`.

## Description
In `start.sh` I added a check for valid domains to the block in the loop over `PIHOLE_DNS_`. The valid domains are resolved and the IP addresses are added to the configs in the same way as DNS servers specified as IPs. I also slightly rearranged the if block to avoid duplicating the warning about invalid servers.

## Motivation and Context 
I have a setup that uses an unbound container to provide DoT. I'm trying to integrate this composition as a stack in a swarm and it would greatly simplify the configuration if docker service names could be used. It would also make the behavior of this image more idiomatic. 

## How Has This Been Tested?
1. `ARCH=amd64 ./gh-actions-test.sh` 25 passed, 11 skipped
3. Using the docker-compose.yml  (below) with `PIHOLE_DNS_` set to "unbound;1.2.3.4" I started the composition.
4. I logged in to the pi-hole admin UI and verified the IP of the unbound container was set as the first custom server and 1.2.3.4 was the second. Then I removed the etc-* directories created in the working directory.
5. I repeated this with just IPv4 addresses.
6. I repeated this with just IPv6 addresses. The parts related to my change worked, but this produced an unrelated pihole-FTL error that exists in `pihole/pihole:latest` as well.
7. I repeated this with just the docker link.
Except for the IPv6 only test the specified IPs or IPs of specified service names were shown as the custom DNS servers and no errors were apparent in the logs.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project. (I tried to be consistent with the surrounding code)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

```
version: "2"

services:
  pihole:
    container_name: pihole
    image: pihole:support-docker-links-for-PIHOLE_DNS_dev-amd64-buster
    ports:
      - "53:53/tcp"
      - "53:53/udp"
      #- "67:67/udp"  # Required for DHCP
      - "80:80/tcp"
    environment:
      TZ: "America/New_York"
      PIHOLE_DNS_: "unbound;1.2.3.4"
    volumes:
      - "./etc-pihole:/etc/pihole"
      - "./etc-dnsmasq.d:/etc/dnsmasq.d"
    #cap_add:  # Required for DHCP
    #  - NET_ADMIN
    restart: unless-stopped

  unbound:
    image: haxwithaxe/unbound-dot:latest
```