### PR TITLE
Test fix for moby security update.

### DIFF
--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -3,7 +3,7 @@
 . /opt/pihole/webpage.sh
 
 fix_capabilities() {
-    setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN,CAP_SYS_NICE,CAP_CHOWN+ei $(which pihole-FTL) || ret=$?
+    setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN,CAP_SYS_NICE,CAP_CHOWN+ep $(which pihole-FTL) || ret=$?
 
     if [[ $ret -ne 0 && "${DNSMASQ_USER:-pihole}" != "root" ]]; then
         echo "ERROR: Unable to set capabilities for pihole-FTL. Cannot run as non-root."


### PR DESCRIPTION
Change the permissions to `permitted` instead of `inherited`.

See https://github.com/moby/moby/issues/43420#issuecomment-1077870013
