### PR TITLE
Use permitted instead of inherited caps.

### DIFF
--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -3,7 +3,7 @@
 . /opt/pihole/webpage.sh
 
 fix_capabilities() {
-    setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN,CAP_SYS_NICE,CAP_CHOWN,CAP_DAC_OVERRIDE+ei $(which pihole-FTL) || ret=$?
+    setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN,CAP_SYS_NICE,CAP_CHOWN,CAP_DAC_OVERRIDE+ep $(which pihole-FTL) || ret=$?
 
     if [[ $ret -ne 0 && "${DNSMASQ_USER:-pihole}" != "root" ]]; then
         echo "ERROR: Unable to set capabilities for pihole-FTL. Cannot run as non-root."


### PR DESCRIPTION
The additional DAC_OVERRIDE permission should fix the docker engine security patch.