### PR TITLE
Upgrade to Bullseye base image instead of buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG PIHOLE_BASE
-FROM "${PIHOLE_BASE:-ghcr.io/pi-hole/docker-pi-hole-base:buster-slim}"
+FROM "${PIHOLE_BASE:-ghcr.io/pi-hole/docker-pi-hole-base:bullseye-slim}"
 
 ARG PIHOLE_DOCKER_TAG
 ENV PIHOLE_DOCKER_TAG "${PIHOLE_DOCKER_TAG}"


### PR DESCRIPTION
## Description

Time to try bullseye again, as we are seeing some issues that will require us to be on bullseye base image, it seems.

Local testing shows that the issues raised in #1002 are not reproducable any longer, but I will need to ask the reporters once `dev` has rebuilt to include this change
