### PR TITLE
Docker 20.10.14 binary capabilites update.

### DIFF
--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -3,7 +3,7 @@
 . /opt/pihole/webpage.sh
 
 fix_capabilities() {
-    setcap CAP_CHOWN,CAP_NET_BIND_SERVICE,CAP_NET_ADMIN,CAP_NET_RAW,CAP_SYS_NICE+ep $(which pihole-FTL) || ret=$?
+    setcap CAP_CHOWN,CAP_NET_BIND_SERVICE,CAP_NET_ADMIN,CAP_NET_RAW+ep $(which pihole-FTL) || ret=$?
 
     if [[ $ret -ne 0 && "${DNSMASQ_USER:-pihole}" != "root" ]]; then
         echo "ERROR: Unable to set capabilities for pihole-FTL. Cannot run as non-root."

--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -3,7 +3,7 @@
 . /opt/pihole/webpage.sh
 
 fix_capabilities() {
-    setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN,CAP_SYS_NICE,CAP_CHOWN,CAP_DAC_OVERRIDE+ei $(which pihole-FTL) || ret=$?
+    setcap CAP_CHOWN,CAP_NET_BIND_SERVICE,CAP_NET_ADMIN,CAP_NET_RAW,CAP_SYS_NICE+ep $(which pihole-FTL) || ret=$?
 
     if [[ $ret -ne 0 && "${DNSMASQ_USER:-pihole}" != "root" ]]; then
         echo "ERROR: Unable to set capabilities for pihole-FTL. Cannot run as non-root."

--- a/s6/debian-root/etc/services.d/pihole-FTL/run
+++ b/s6/debian-root/etc/services.d/pihole-FTL/run
@@ -20,7 +20,7 @@ chown -f pihole:pihole /etc/pihole/pihole-FTL.db /etc/pihole/gravity.db /etc/pih
 # Chown database file permissions so that the pihole group (web interface) can edit the file. We ignore errors as the files may not (yet) exist
 chmod -f 0664 /etc/pihole/pihole-FTL.db
 
-s6-setuidgid ${DNSMASQ_USER} pihole-FTL $FTL_CMD >/dev/null 2>&1
+s6-setuidgid root capsh --addamb="cap_chown,cap_net_bind_service,cap_net_admin,cap_net_raw,cap_sys_nice+ep" --user=$DNSMASQ_USER --keep=1 -- -c "/usr/bin/pihole-FTL $FTL_CMD" 
 
 # Notes on above:
 # - DNSMASQ_USER default of pihole is in Dockerfile & can be overwritten by runtime container env

--- a/s6/debian-root/etc/services.d/pihole-FTL/run
+++ b/s6/debian-root/etc/services.d/pihole-FTL/run
@@ -20,7 +20,7 @@ chown -f pihole:pihole /etc/pihole/pihole-FTL.db /etc/pihole/gravity.db /etc/pih
 # Chown database file permissions so that the pihole group (web interface) can edit the file. We ignore errors as the files may not (yet) exist
 chmod -f 0664 /etc/pihole/pihole-FTL.db
 
-s6-setuidgid root capsh --inh=cap_net_raw,cap_chown,cap_setpcap,cap_net_bind_service,cap_net_admin,cap_dac_override --addamb=cap_setpcap,cap_chown,cap_net_bind_service,cap_net_admin,cap_net_raw,cap_dac_override,cap_setpcap+i --user=$DNSMASQ_USER --keep=1 -- -c "/usr/bin/pihole-FTL $FTL_CMD" 
+capsh --inh=cap_net_raw,cap_chown,cap_setpcap,cap_net_bind_service,cap_net_admin,cap_dac_override --addamb=cap_setpcap,cap_chown,cap_net_bind_service,cap_net_admin,cap_net_raw,cap_dac_override,cap_setpcap --user=$DNSMASQ_USER --keep=1 -- -c "/usr/bin/pihole-FTL $FTL_CMD" 
 
 # Notes on above:
 # - DNSMASQ_USER default of pihole is in Dockerfile & can be overwritten by runtime container env

--- a/s6/debian-root/etc/services.d/pihole-FTL/run
+++ b/s6/debian-root/etc/services.d/pihole-FTL/run
@@ -20,7 +20,7 @@ chown -f pihole:pihole /etc/pihole/pihole-FTL.db /etc/pihole/gravity.db /etc/pih
 # Chown database file permissions so that the pihole group (web interface) can edit the file. We ignore errors as the files may not (yet) exist
 chmod -f 0664 /etc/pihole/pihole-FTL.db
 
-s6-setuidgid root capsh --addamb="cap_chown,cap_net_bind_service,cap_net_admin,cap_net_raw,cap_sys_nice+ep" --user=$DNSMASQ_USER --keep=1 -- -c "/usr/bin/pihole-FTL $FTL_CMD" 
+s6-setuidgid root capsh --inh=cap_net_raw,cap_chown,cap_setpcap,cap_net_bind_service,cap_net_admin,cap_dac_override --addamb=cap_setpcap,cap_chown,cap_net_bind_service,cap_net_admin,cap_net_raw,cap_dac_override,cap_setpcap+i --user=$DNSMASQ_USER --keep=1 -- -c "/usr/bin/pihole-FTL $FTL_CMD" 
 
 # Notes on above:
 # - DNSMASQ_USER default of pihole is in Dockerfile & can be overwritten by runtime container env


### PR DESCRIPTION
Potential fix for the capabilities issue for docker engine 20.10.14.

Issue is from https://github.com/moby/moby/issues/43420#issuecomment-1077870013 and a security fix.

Due to a bug in the https://bugzilla.redhat.com/show_bug.cgi?id=1950187 library that wipes ambient permission when the effective user is changed, we have to set the capabilities in two steps. 

Set the effective and permitted to the binary via `setcap` to allow for ambient usage of those caps.

Start the binary with `capsh` and apply the capabilities for ambient there.