### PR TITLE
Add touch guards for Buster hosts and Bullseye images.

### DIFF
--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -20,7 +20,12 @@ prepare_configs() {
     LIGHTTPD_GROUP="www-data"
     LIGHTTPD_CFG="lighttpd.conf.debian"
     installConfigs
-    touch "$setupVars"
+   
+    if [ ! -f "${setupVars}" ]; then
+        touch "${setupVars}"
+        echo "Creating empty ${setupVars} file."
+    fi
+    
     set +e
     mkdir -p /var/run/pihole /var/log/pihole
     

--- a/install.sh
+++ b/install.sh
@@ -74,6 +74,7 @@ if [[ "${PIHOLE_DOCKER_TAG}" != "dev" && "${PIHOLE_DOCKER_TAG}" != "nightly" ]];
   sed -i $'s/)\s*piholeCheckoutFunc/) unsupportedFunc/g' /usr/local/bin/pihole
 fi
 
-touch /.piholeFirstBoot
-
+if [ ! -f /.piholeFirstBoot ]; then
+  touch /.piholeFirstBoot
+fi
 echo 'Docker install successful'

--- a/s6/debian-root/etc/services.d/lighttpd/run
+++ b/s6/debian-root/etc/services.d/lighttpd/run
@@ -19,8 +19,10 @@ else
   #remove fifo if exists
   [[ -p /var/log/lighttpd/access.log ]] && rm -Rf /var/log/lighttpd/access.log
   [[ -p  /var/log/lighttpd/error.log ]] && rm -Rf /var/log/lighttpd/error.log
+
   # Touch log files to ensure they exist (create if non-existing, preserve if existing)
-  touch /var/log/lighttpd/access.log /var/log/lighttpd/error.log
+  [[ ! -f /var/log/lighttpd/access.log ]] && touch /var/log/lighttpd/access.log
+  [[ ! -f  /var/log/lighttpd/error.log ]] && touch /var/log/lighttpd/error.log
 
   # Ensure that permissions are set so that lighttpd can write to the logs
   chown -R www-data:www-data /var/log/lighttpd

--- a/s6/debian-root/etc/services.d/pihole-FTL/run
+++ b/s6/debian-root/etc/services.d/pihole-FTL/run
@@ -7,7 +7,11 @@ rm /run/pihole/FTL.sock 2> /dev/null
 
 # Touch files to ensure they exist (create if non-existing, preserve if existing)
 mkdir -pm 0755 /run/pihole
-touch /run/pihole-FTL.pid /run/pihole-FTL.port /var/log/pihole-FTL.log /var/log/pihole.log /etc/pihole/dhcp.leases
+[[ ! -f /run/pihole-FTL.pid ]] && touch /run/pihole-FTL.pid
+[[ ! -f /run/pihole-FTL.port ]] && touch /run/pihole-FTL.port
+[[ ! -f /var/log/pihole-FTL.log ]] && touch /var/log/pihole-FTL.log
+[[ ! -f /var/log/pihole.log ]] && touch /var/log/pihole.log
+[[ ! -f /etc/pihole/dhcp.leases ]] && touch /etc/pihole/dhcp.leases
 
 # Ensure that permissions are set so that pihole-FTL can edit all necessary files
 chown pihole:pihole /run/pihole-FTL.pid /run/pihole-FTL.port /var/log/pihole-FTL.log /var/log/pihole.log /etc/pihole/dhcp.leases /run/pihole /etc/pihole


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Buster hosts don't like to `touch` existing files. Too many germs and, well, we don't touch strangers now.