### PR TITLE
Apply detected capabilities and disable DHCP if not capable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ services:
       - './etc-dnsmasq.d:/etc/dnsmasq.d'    
     #   https://github.com/pi-hole/docker-pi-hole#note-on-capabilities
     cap_add:
-      - NET_ADMIN # Required if you are using Pi-hole as yuour DHCP server, else not needed
+      - NET_ADMIN # Required if you are using Pi-hole as your DHCP server, else not needed
     restart: unless-stopped
 ```
 2. Run `docker-compose up -d` to build and start pi-hole

--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -7,21 +7,33 @@ fix_capabilities() {
     # Current: cap_chown,cap_dac_override,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,cap_net_bind_service,cap_net_raw,cap_sys_chroot,cap_mknod,cap_audit_write,cap_setfcap=ep
     # FTL can also use CAP_NET_ADMIN and CAP_SYS_NICE. If we try to set them when they haven't been explicitly enabled, FTL will not start. Test for them first:
     
-    capsh --print | grep "Current:" | grep -q cap_chown && CAP_STR+=',CAP_CHOWN'
-    capsh --print | grep "Current:" | grep -q cap_net_bind_service && CAP_STR+=',CAP_NET_BIND_SERVICE'
-    capsh --print | grep "Current:" | grep -q cap_net_raw && CAP_STR+=',CAP_NET_RAW'
-    capsh --print | grep "Current:" | grep -q cap_net_admin && CAP_STR+=',CAP_NET_ADMIN'
-    capsh --print | grep "Current:" | grep -q cap_sys_nice && CAP_STR+=',CAP_SYS_NICE'    
+    /sbin/capsh '==' --print | grep "Current:" | grep -q cap_chown && CAP_STR=',CAP_CHOWN'
+    /sbin/capsh '==' --print | grep "Current:" | grep -q cap_net_bind_service && CAP_STR+=',CAP_NET_BIND_SERVICE'
+    /sbin/capsh '==' --print | grep "Current:" | grep -q cap_net_raw && CAP_STR+=',CAP_NET_RAW'
+    /sbin/capsh '==' --print | grep "Current:" | grep -q cap_net_admin && CAP_STR+=',CAP_NET_ADMIN' || DHCP_READY='false'
+    /sbin/capsh '==' --print | grep "Current:" | grep -q cap_sys_nice && CAP_STR+=',CAP_SYS_NICE'    
 
     if [[ ${CAP_STR} ]]; then
         # We have the (some of) the above caps available to us - apply them to pihole-FTL
         setcap ${CAP_STR:1}+ep $(which pihole-FTL) || ret=$?
+
+        if [[ $DHCP_READY == false ]] && [[ $DHCP_ACTIVE == true ]]; then
+            # DHCP is requested but NET_ADMIN is not available.
+            echo "ERROR: DHCP requested but NET_ADMIN is not available. DHCP will not be started."
+            echo "      Please add cap_net_admin to the container's capabilities or disable DHCP."
+            DHCP_ACTIVE='false'
+            change_setting "DHCP_ACTIVE" "false"
+        fi
         
         if [[ $ret -ne 0 && "${DNSMASQ_USER:-pihole}" != "root" ]]; then
             echo "ERROR: Unable to set capabilities for pihole-FTL. Cannot run as non-root."
             echo "       If you are seeing this error, please set the environment variable 'DNSMASQ_USER' to the value 'root'"
             exit 1
         fi   
+    else
+        echo "WARNING: Unable to set capabilities for pihole-FTL."
+        echo "         Please ensure that the container has the required capabilities."
+        exit 1
     fi
 }
 

--- a/s6/debian-root/etc/services.d/pihole-FTL/run
+++ b/s6/debian-root/etc/services.d/pihole-FTL/run
@@ -24,7 +24,8 @@ chown -f pihole:pihole /etc/pihole/pihole-FTL.db /etc/pihole/gravity.db /etc/pih
 # Chown database file permissions so that the pihole group (web interface) can edit the file. We ignore errors as the files may not (yet) exist
 chmod -f 0664 /etc/pihole/pihole-FTL.db
 
-s6-setuidgid ${DNSMASQ_USER} /usr/bin/pihole-FTL $FTL_CMD >/dev/null 2>&1
+# Call capsh with the detected capabilities
+capsh --inh=${CAP_STR:1} --addamb=${CAP_STR:1} --user=$DNSMASQ_USER --keep=1 -- -c "/usr/bin/pihole-FTL $FTL_CMD" 
 
 # Notes on above:
 # - DNSMASQ_USER default of pihole is in Dockerfile & can be overwritten by runtime container env


### PR DESCRIPTION
`s6-setuidgid` changes users and the new docker binary drops all capabilities on user change. Revert the revert to use `capsh` again to push caps to Ambient. 

Detect if NET_ADMIN is not available and DHCP_ACTIVE=true. Warn user that DHCP will not be started but continue in DNS only mode.

Tested with the following runs on Debian Buster:

```bash
  docker run -it --rm --name=pitest --network=host -e FTLCONF_DEBUG_CAPS=true -e DHCP_ACTIVE=true -e DHCP_START=8.8.8.8 -e DHCP_END=9.9.9.9 -e DHCP_ROUTER=12.12.12.12 djschaper/pihole-caps-test:new
  docker pull djschaper/pihole-caps-test:new
  docker run -it --rm --name=pitest --network=host -e FTLCONF_DEBUG_CAPS=true -e DHCP_ACTIVE=true -e DHCP_START=8.8.8.8 -e DHCP_END=9.9.9.9 -e DHCP_ROUTER=12.12.12.12 djschaper/pihole-caps-test:new
  docker run -it --rm --name=pitest --network=host -e FTLCONF_DEBUG_CAPS=true  djschaper/pihole-caps-test:new
  docker run -it --rm --name=pitest  -e FTLCONF_DEBUG_CAPS=true -e DHCP_ACTIVE=true -e DHCP_START=8.8.8.8 -e DHCP_END=9.9.9.9 -e DHCP_ROUTER=12.12.12.12 djschaper/pihole-caps-test:new
   docker run -it --rm --name=pitest djschaper/pihole-caps-test:new
```
DHCP && host network
DHCP && bridge network
NO DHCP && host network
NO DHCP && bridge network

All good. 



