### PR TITLE
Replace one more instance of `touch` with `install /dev/null`

### DIFF
--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -47,7 +47,7 @@ prepare_configs() {
     installConfigs
    
     if [ ! -f "${setupVars}" ]; then
-        install /dev/null "${setupVars}"
+        install -m 644 /dev/null "${setupVars}"
         echo "Creating empty ${setupVars} file."
     fi
     

--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -47,7 +47,7 @@ prepare_configs() {
     installConfigs
    
     if [ ! -f "${setupVars}" ]; then
-        touch "${setupVars}"
+        install /dev/null "${setupVars}"
         echo "Creating empty ${setupVars} file."
     fi
     


### PR DESCRIPTION
This one was missed, noticed issues when running current images on `buster` (without updated `libseccomp`), this PR brings the usage in line with the changes that were made to the FTL S6 service script