### PR TITLE
read pids into an array in case of multiple instances of FTL running.…

### DIFF
--- a/s6/service
+++ b/s6/service
@@ -1,8 +1,9 @@
 #!/bin/bash
 # This script patches all service commands into the appropriate s6- commands
 # pi-hole upstream scripts need a 'service' interface. why not systemd? docker said so.
+
 start() {
-  s6-svc -wu -u -T2500 /var/run/s6/services/$service
+  restart
 }
 
 stop() {
@@ -12,16 +13,18 @@ stop() {
 restart() {
   local pid
 
-  # Get the PID of the service we are asking to restart
-  pid=$(pgrep $service)
+  # Get the PID(s) of the service we are asking to restart
+  mapfile -t pids < <(pgrep $service)  
 
   # Only attempt to stop the service if it is already running
-  if [ -n "$pid" ]; then
+  if [ "${#pids[@]}" -gt 0 ]; then
     stop
 
-    # Loop until we are certain that the process has been stopped
-    while test -d /proc/$pid; do
-      sleep 0.2
+    for pid in "${pids[@]}"; do
+      # Loop until we are certain that the process has been stopped
+      while test -d /proc/$pid; do
+        sleep 0.2
+      done
     done
   fi
 
@@ -30,7 +33,7 @@ restart() {
   
   # Only attempt to start the service if it is not already running
   if [ -z "$pid" ]; then
-    start
+    s6-svc -wu -u -T2500 /var/run/s6/services/$service
   fi
   
 }


### PR DESCRIPTION
## Description

Adds some guarding around the checks to see if an existing instance of $service is running on the rare occasion that there are multiples. I'm not sure what it takes to reproduce the issue, but I've been able to get it to happen intermittently on `latest`, `dev` and `nightly`.

Additionally moves the actual service start into the `restart()` function, and have the `start()` function call `restart()` to effectively restart the service rather than attempt to start another one.

## How Has This Been Tested?

restarted services loads

![image](https://user-images.githubusercontent.com/1998970/162820865-e7c35c49-adf6-491b-b578-984c80ecd929.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.