### PR TITLE
Update README.md to mention minimum required docker version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
   The first recommendation is to upgrade your host OS, which will include a more up to date (and fixed) version of `libseccomp`. 
   
-  _If you absolutely cannot do this, some users [have reported](https://github.com/pi-hole/docker-pi-hole/issues/1042#issuecomment-1086728157) success in updating `libseccomp2` via backports on debian, or similar via updates on Ubuntu. You can try this workaround at your own risk_  
+  _If you absolutely cannot do this, some users [have reported](https://github.com/pi-hole/docker-pi-hole/issues/1042#issuecomment-1086728157) success in updating `libseccomp2` via backports and `docker.io` from bullseye on debian (more details [here](https://blog.samcater.com/fix-workaround-rpi4-docker-libseccomp2-docker-20/)) on debian, or similar via updates on Ubuntu. You can try this workaround at your own risk_  
 
 - Some users [have reported issues](https://github.com/pi-hole/docker-pi-hole/issues/963#issuecomment-1095602502) with using the `--privileged` flag on `2022.04` and above. TL;DR, don't use that that mode, and be [explicit with the permitted caps](https://github.com/pi-hole/docker-pi-hole#note-on-capabilities) (if needed) instead
 


### PR DESCRIPTION
Signed-off-by: Nicola Canepa <nicola.canepa.74@gmail.com>
Mention the required update to docker.io in additon to libseccomp2 on ARM

## Description
According to my experience and to some other reports, updating libseccomp2 is not enough if Docker is at version 18 (the one available with Buster/ARM)

## Motivation and Context
Improve the documentation and improve user experience/troubleshooting

## How Has This Been Tested?
SImple update to the README file

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
