### PR TITLE
Update default debian to bullseye. Update README to describe docker tags.

### DIFF
--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ARCH: amd64
-      DEBIAN_VERSION: buster
+      DEBIAN_VERSION: bullseye
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/Dockerfile.sh
+++ b/Dockerfile.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # @param ${ARCH}             The architecture to build. Example: amd64
-# @param ${DEBIAN_VERSION}   The debian version to build. Example: buster
+# @param ${DEBIAN_VERSION}   The debian version to build. Example: bullseye
 # @param ${ARCH_IMAGE}       What the Docker Hub Image should be tagged as [default: None]
 
 set -eux

--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -1,4 +1,4 @@
-FROM python:3.8-buster
+FROM python:3.8-bullseye
 
 # Only works for docker CLIENT (bind mounted socket)
 COPY --from=docker:18.09.3 /usr/local/bin/docker /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -222,23 +222,16 @@ Users of older Ubuntu releases (circa 17.04) will need to disable dnsmasq.
 
 ## Docker tags and versioning
 
-The primary docker tags / versions are explained in the following table.  [Click here to see the full list of tags](https://store.docker.com/community/images/pihole/pihole/tags), I also try to tag with the specific version of Pi-hole Core for version archival purposes, the web version that comes with the core releases should be in the [GitHub Release notes](https://github.com/pi-hole/docker-pi-hole/releases).
+The primary docker tags are explained in the following table.  [Click here to see the full list of tags](https://store.docker.com/community/images/pihole/pihole/tags). See [GitHub Release notes](https://github.com/pi-hole/docker-pi-hole/releases) to see the specific version of Pi-hole Core, Web, and FTL included in the release.
 
-| tag                     | architecture | description                                                             | Dockerfile |
-| ---                     | ------------ | -----------                                                             | ---------- |
-| `latest`                | auto detect  | x86, arm, or arm64 container, docker auto detects your architecture.    | [Dockerfile](https://github.com/pi-hole/docker-pi-hole/blob/master/Dockerfile) |
-| `v5.0`                  | auto detect  | Versioned tags, if you want to pin against a specific Pi-hole version, use one of these |  |
-| `v5.0-buster`           | auto detect  | Versioned tags, if you want to pin against a specific Pi-hole and Debian version, use one of these |  |
-| `v5.0-<arch>-buster `   | based on tag | Specific architectures and Debian version tags | |
-| `dev`                   | auto detect  | like latest tag, but for the development branch (pushed occasionally)   | |
-| `beta-*`                | auto detect  | Early beta releases of upcoming versions - here be dragons              | |
-| `nightly`               | auto detect  | Like `dev` but pushed every night and pulls from the latest `development` branches of the core Pi-hole components (Pi-hole, AdminLTE, FTL)  | |
-
-### `pihole/pihole:latest` [![](https://images.microbadger.com/badges/image/pihole/pihole:latest.svg)](https://microbadger.com/images/pihole/pihole "Get your own image badge on microbadger.com") [![](https://images.microbadger.com/badges/version/pihole/pihole:latest.svg)](https://microbadger.com/images/pihole/pihole "Get your own version badge on microbadger.com") [![](https://images.microbadger.com/badges/version/pihole/pihole:latest.svg)](https://microbadger.com/images/pihole/pihole "Get your own version badge on microbadger.com")
-
-This version of the docker aims to be as close to a standard Pi-hole installation by using the recommended base OS and the exact configs and scripts (minimally modified to get them working).  This enables fast updating when an update comes from Pi-hole.
-
-https://hub.docker.com/r/pihole/pihole/tags/
+| tag                 | description                                                                                                                                
+|---------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| `latest`            | Always latest release                                                                                                                      |
+| `2022.04`           | Date-based release that can receive bugfix updates                                                                                         |
+| `2022.04.1`         | A specific image that will not receive updates                                                                                             |
+| `dev`               | Similar to `latest`, but for the development branch (pushed occasionally)                                                                  |
+| `*beta`             | Early beta releases of upcoming versions - here be dragons                                                                                 |
+| `nightly`           | Like `dev` but pushed every night and pulls from the latest `development` branches of the core Pi-hole components (Pi-hole, AdminLTE, FTL) |
 
 ## Upgrading, Persistence, and Customizations
 

--- a/build.yml
+++ b/build.yml
@@ -9,9 +9,9 @@ x-common-args: &common-args
 
 services:
   amd64:
-    image: pihole:${PIHOLE_DOCKER_TAG}-amd64-${DEBIAN_VERSION:-buster}
+    image: pihole:${PIHOLE_DOCKER_TAG}-amd64-${DEBIAN_VERSION:-bullseye}
     build:
       context: .
       args:
         <<: *common-args
-        PIHOLE_BASE: ghcr.io/pi-hole/docker-pi-hole-base:${DEBIAN_VERSION:-buster}-slim
+        PIHOLE_BASE: ghcr.io/pi-hole/docker-pi-hole-base:${DEBIAN_VERSION:-bullseye}-slim

--- a/gh-actions-test.sh
+++ b/gh-actions-test.sh
@@ -4,8 +4,8 @@ set -ex
 # Script ran by Github actions for tests
 #
 # @environment ${ARCH}              The architecture to build. Example: amd64.
-# @environment ${DEBIAN_VERSION}    Debian version to build. ('buster' or 'stretch').
-# @environment ${ARCH_IMAGE}        What the Docker Hub Image should be tagged as. Example: pihole/pihole:master-amd64-buster
+# @environment ${DEBIAN_VERSION}    Debian version to build. ('bullseye' or 'buster').
+# @environment ${ARCH_IMAGE}        What the Docker Hub Image should be tagged as. Example: pihole/pihole:master-amd64-bullseye
 
 # setup qemu/variables
 docker run --rm --privileged multiarch/qemu-user-static:register --reset > /dev/null

--- a/gh-actions-vars.sh
+++ b/gh-actions-vars.sh
@@ -2,14 +2,14 @@
 set -a
 
 # @environment ${ARCH}                    The architecture to build. Defaults to 'amd64'.
-# @environment ${DEBIAN_VERSION}          Debian version to build. Defaults to 'buster'.
+# @environment ${DEBIAN_VERSION}          Debian version to build. Defaults to 'bullseye'.
 # @environment ${DOCKER_HUB_REPO}         The docker hub repo to tag images for. Defaults to 'pihole'.
 # @environment ${DOCKER_HUB_IMAGE_NAME}   The name of the resulting image. Defaults to 'pihole'.
 
 GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD | sed "s/\//-/g")
 GIT_TAG=$(git describe --tags --exact-match 2> /dev/null || true)
 
-DEFAULT_DEBIAN_VERSION="buster"
+DEFAULT_DEBIAN_VERSION="bullseye"
 
 if [[ -z "${ARCH}" ]]; then
     ARCH="amd64"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -7,7 +7,7 @@ import testinfra
 local_host = testinfra.get_host('local://')
 check_output = local_host.check_output
 
-DEBIAN_VERSION = os.environ.get('DEBIAN_VERSION', 'buster')
+DEBIAN_VERSION = os.environ.get('DEBIAN_VERSION', 'bullseye')
 
 @pytest.fixture()
 def run_and_stream_command_output():

--- a/test/test_volume_data.sh
+++ b/test/test_volume_data.sh
@@ -33,7 +33,7 @@ trap "cleanup" INT TERM EXIT
 # VOLUME TESTS
 
 # Given...
-DEBIAN_VERSION="$(DEBIAN_VERSION:-buster)"
+DEBIAN_VERSION="$(DEBIAN_VERSION:-bullseye)"
 IMAGE="${1:-pihole:v5.0-amd64}-${DEBIAN_VERSION}"   # Default is latest build test image (generic, non release/branch tag)
 VOLUMES="$(mktemp -d)"                              # A fresh volume directory
 VOL_PH="$VOLUMES/pihole"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

It looks like Bullseye is already the default (only) debian version we are using - so bump the other defaults to bullseye as well. 

Also, update the README to better match the current docker tagging pattern.


## Motivation and Context

Mostly just some cleanup as I catch back up on this project

## How Has This Been Tested?

No testing other then Github Actions - the defaults shouldn't really change anything functional since we're already building bullseye images.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
