### PR TITLE
Fix capability detection for privileged containers

### DIFF
--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -7,11 +7,11 @@ fix_capabilities() {
     # Current: cap_chown,cap_dac_override,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,cap_net_bind_service,cap_net_raw,cap_sys_chroot,cap_mknod,cap_audit_write,cap_setfcap=ep
     # FTL can also use CAP_NET_ADMIN and CAP_SYS_NICE. If we try to set them when they haven't been explicitly enabled, FTL will not start. Test for them first:
     
-    /sbin/capsh '==' --print | grep "Current:" | grep -q cap_chown && CAP_STR+=',CAP_CHOWN'
-    /sbin/capsh '==' --print | grep "Current:" | grep -q cap_net_bind_service && CAP_STR+=',CAP_NET_BIND_SERVICE'
-    /sbin/capsh '==' --print | grep "Current:" | grep -q cap_net_raw && CAP_STR+=',CAP_NET_RAW'
-    /sbin/capsh '==' --print | grep "Current:" | grep -q cap_net_admin && CAP_STR+=',CAP_NET_ADMIN' || DHCP_READY='false'
-    /sbin/capsh '==' --print | grep "Current:" | grep -q cap_sys_nice && CAP_STR+=',CAP_SYS_NICE'    
+    /sbin/capsh --has-p=cap_chown && CAP_STR+=',CAP_CHOWN'
+    /sbin/capsh --has-p=cap_net_bind_service && CAP_STR+=',CAP_NET_BIND_SERVICE'
+    /sbin/capsh --has-p=cap_net_raw && CAP_STR+=',CAP_NET_RAW'
+    /sbin/capsh --has-p=cap_net_admin && CAP_STR+=',CAP_NET_ADMIN' || DHCP_READY='false'
+    /sbin/capsh --has-p=cap_sys_nice && CAP_STR+=',CAP_SYS_NICE'    
 
     if [[ ${CAP_STR} ]]; then
         # We have the (some of) the above caps available to us - apply them to pihole-FTL


### PR DESCRIPTION
## Description

Privileged containers do not list each cap by name,
instead they lead with `=eip` and selectively remove
caps with `cap_foo_bar-eip`.

Instead we can use the `--has-p` flag of capsh to check
for the permitted cap.

See: https://k3a.me/linux-capabilities-in-a-nutshell/
See: https://man7.org/linux/man-pages/man1/capsh.1.html

## Motivation and Context

This will allow privileged containers to not fail the `fix_capabilities` check as they do today.

```
 pihole  WARNING: Unable to set capabilities for pihole-FTL.
 pihole           Please ensure that the container has the required capabilities.
 pihole  [cont-init.d] 20-start.sh: exited 1.
 ```

## How Has This Been Tested?

Confirmed on a Ubuntu desktop environment with Docker 20.10 that privileged containers do not show all the caps expected by the `fix_capabilities` function. Instead it adopts all caps (`=eip`) and specifically removes some.

```bash
$ docker run --rm -it alpine sh -c 'apk add --no-cache libcap && capsh == --print | grep Current: | grep -q cap_net_admin ; echo $?'
1
```
```bash
$ docker run --rm -it --cap-add NET_ADMIN alpine sh -c 'apk add --no-cache libcap && capsh == --print | grep Current: | grep -q cap_net_admin ; echo $?'
0
```
```bash
$ docker run --rm -it --privileged alpine sh -c 'apk add --no-cache libcap && capsh == --print | grep Current: | grep -q cap_net_admin ; echo $?'
1 # we are privileged so this should be 0
```

However, the `--has-p` flag will correctly identify the permitted capabilities.

```bash
$ docker run --rm -it alpine sh -c 'apk add --no-cache libcap && capsh --has-p=cap_net_admin ; echo $?'
cap[cap_net_admin] not permitted
1
```
```bash
$ docker run --rm -it --cap-add NET_ADMIN alpine sh -c 'apk add --no-cache libcap && capsh --has-p=cap_net_admin ; echo $?'
0
```
```bash
$ docker run --rm -it --privileged alpine sh -c 'apk add --no-cache libcap && capsh --has-p=cap_net_admin ; echo $?'
0 # much better!
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
