### PR TITLE
Allow pihole checkout on any image rather than just dev/nightly image…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -76,11 +76,6 @@ sed -i $'s/)\s*uninstallFunc/) unsupportedFunc/g' /usr/local/bin/pihole
 # pihole -r / pihole reconfigure
 sed -i $'s/)\s*reconfigurePiholeFunc/) unsupportedFunc/g' /usr/local/bin/pihole
 
-if [[ "${PIHOLE_DOCKER_TAG}" != "dev" && "${PIHOLE_DOCKER_TAG}" != "nightly" ]]; then
-  # If we are on a version other than dev or nightly, disable `pihole checkout`, otherwise it is useful to have for quick troubleshooting sometimes
-  sed -i $'s/)\s*piholeCheckoutFunc/) unsupportedFunc/g' /usr/local/bin/pihole
-fi
-
 if [ ! -f /.piholeFirstBoot ]; then
   touch /.piholeFirstBoot
 fi


### PR DESCRIPTION
## Description

Allows `pihole checkout` to be run, even on versioned/`:latest` tags, in my opinion there isn't a real need to be supressing this functionality in a docker container - it is still useful for troubleshooting

## Motivation and Context

https://github.com/pi-hole/FTL/issues/1348#issuecomment-1133841419

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.