### PR TITLE
Always use WEBPASSWORD env var if set

### DIFF
--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -6,12 +6,12 @@ fix_capabilities() {
     # Testing on Docker 20.10.14 with no caps set shows the following caps available to the container:
     # Current: cap_chown,cap_dac_override,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,cap_net_bind_service,cap_net_raw,cap_sys_chroot,cap_mknod,cap_audit_write,cap_setfcap=ep
     # FTL can also use CAP_NET_ADMIN and CAP_SYS_NICE. If we try to set them when they haven't been explicitly enabled, FTL will not start. Test for them first:
-    
+
     /sbin/capsh --has-p=cap_chown && CAP_STR+=',CAP_CHOWN'
     /sbin/capsh --has-p=cap_net_bind_service && CAP_STR+=',CAP_NET_BIND_SERVICE'
     /sbin/capsh --has-p=cap_net_raw && CAP_STR+=',CAP_NET_RAW'
     /sbin/capsh --has-p=cap_net_admin && CAP_STR+=',CAP_NET_ADMIN' || DHCP_READY='false'
-    /sbin/capsh --has-p=cap_sys_nice && CAP_STR+=',CAP_SYS_NICE'    
+    /sbin/capsh --has-p=cap_sys_nice && CAP_STR+=',CAP_SYS_NICE'
 
     if [[ ${CAP_STR} ]]; then
         # We have the (some of) the above caps available to us - apply them to pihole-FTL
@@ -24,12 +24,12 @@ fix_capabilities() {
             DHCP_ACTIVE='false'
             change_setting "DHCP_ACTIVE" "false"
         fi
-        
+
         if [[ $ret -ne 0 && "${DNSMASQ_USER:-pihole}" != "root" ]]; then
             echo "ERROR: Unable to set capabilities for pihole-FTL. Cannot run as non-root."
             echo "       If you are seeing this error, please set the environment variable 'DNSMASQ_USER' to the value 'root'"
             exit 1
-        fi   
+        fi
     else
         echo "WARNING: Unable to set capabilities for pihole-FTL."
         echo "         Please ensure that the container has the required capabilities."
@@ -45,21 +45,21 @@ prepare_configs() {
     LIGHTTPD_GROUP="www-data"
     LIGHTTPD_CFG="lighttpd.conf.debian"
     installConfigs
-   
+
     if [ ! -f "${setupVars}" ]; then
         install -m 644 /dev/null "${setupVars}"
         echo "Creating empty ${setupVars} file."
     fi
-    
+
     set +e
     mkdir -p /var/run/pihole /var/log/pihole
-    
+
     chown pihole:root /etc/lighttpd
-    
+
     # In case of `pihole` UID being changed, re-chown the pihole scripts and pihole command
     chown -R pihole:root "${PI_HOLE_INSTALL_DIR}"
     chown pihole:root "${PI_HOLE_BIN_DIR}/pihole"
-    
+
     set -e
     # Update version numbers
     pihole updatechecker
@@ -279,9 +279,21 @@ generate_password() {
 }
 
 setup_web_password() {
-    setup_var_exists "WEBPASSWORD" && return
+    if [ -z "${WEBPASSWORD+x}" ] ; then
+        # ENV WEBPASSWORD is not set
 
-    PASS="$1"
+        # Exit if setupvars already has a password
+        setup_var_exists "WEBPASSWORD" && return
+
+        # Generate new password
+        generate_password
+    else
+        # ENV WEBPASSWORD is set an will be used
+        echo "Assigning password defined by Environment Variable"
+    fi
+
+    PASS="$WEBPASSWORD"
+
     # Explicitly turn off bash printing when working with secrets
     { set +x; } 2>/dev/null
 

--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -289,7 +289,7 @@ setup_web_password() {
         generate_password
     else
         # ENV WEBPASSWORD is set an will be used
-        echo "Assigning password defined by Environment Variable"
+        echo "::: Assigning password defined by Environment Variable"
     fi
 
     PASS="$WEBPASSWORD"

--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -270,13 +270,7 @@ load_web_password_secret() {
    fi;
 }
 
-generate_password() {
-    if [ -z "${WEBPASSWORD+x}" ] ; then
-        # Not set at all, give the user a random pass
-        WEBPASSWORD=$(tr -dc _A-Z-a-z-0-9 < /dev/urandom | head -c 8)
-        echo "Assigning random password: $WEBPASSWORD"
-    fi;
-}
+
 
 setup_web_password() {
     if [ -z "${WEBPASSWORD+x}" ] ; then
@@ -285,8 +279,9 @@ setup_web_password() {
         # Exit if setupvars already has a password
         setup_var_exists "WEBPASSWORD" && return
 
-        # Generate new password
-        generate_password
+        # Generate new random password
+        WEBPASSWORD=$(tr -dc _A-Z-a-z-0-9 < /dev/urandom | head -c 8)
+        echo "Assigning random password: $WEBPASSWORD"
     else
         # ENV WEBPASSWORD is set an will be used
         echo "::: Assigning password defined by Environment Variable"

--- a/start.sh
+++ b/start.sh
@@ -39,6 +39,7 @@ export PIHOLE_DOMAIN
 export DHCP_IPv6
 export DHCP_rapid_commit
 export WEBTHEME
+export WEBPASSWORD
 export CUSTOM_CACHE_SIZE
 
 export adlistFile='/etc/pihole/adlists.list'
@@ -67,7 +68,6 @@ echo " ::: Starting docker specific checks & setup for docker pihole/pihole"
 
 fix_capabilities
 load_web_password_secret
-generate_password
 validate_env || exit 1
 prepare_configs
 
@@ -185,7 +185,7 @@ fi
 [[ -n "${DHCP_ACTIVE}" && ${DHCP_ACTIVE} == "true" ]] && echo "Setting DHCP server" && setup_dhcp
 
 setup_web_port "$WEB_PORT"
-setup_web_password "$WEBPASSWORD"
+setup_web_password
 setup_temp_unit "$TEMPERATUREUNIT"
 setup_ui_layout "$WEBUIBOXEDLAYOUT"
 setup_admin_email "$ADMIN_EMAIL"


### PR DESCRIPTION
## Description
If WEBPASSWORD env variable is set, it will be used.
A new password will be created only if WEBPASSWORD is not set and no password is found in `setupVars.conf`.

## Motivation and Context
Fix https://github.com/pi-hole/docker-pi-hole/issues/1087

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
