### PR TITLE
Var log pihole

### DIFF
--- a/docker-compose-nginx-proxy.yml
+++ b/docker-compose-nginx-proxy.yml
@@ -24,7 +24,7 @@ services:
       - './etc-pihole:/etc/pihole'
       - './etc-dnsmasq.d:/etc/dnsmasq.d'
       # run `touch ./var-log/pihole.log` first unless you like errors
-      # - './var-log/pihole.log:/var/log/pihole.log'
+      # - './var-log/pihole.log:/var/log/pihole/pihole.log'
     # Recommended but not required (DHCP needs NET_ADMIN)
     #   https://github.com/pi-hole/docker-pi-hole#note-on-capabilities
     cap_add:

--- a/s6/debian-root/etc/cont-init.d/20-start.sh
+++ b/s6/debian-root/etc/cont-init.d/20-start.sh
@@ -28,7 +28,7 @@ if [ -z "$SKIPGRAVITYONBOOT" ] || [ ! -e "${gravityDBfile}" ]; then
         echo "  Ignoring SKIPGRAVITYONBOOT on this occaision."
     fi
 
-    echo '@reboot root PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole updateGravity >/var/log/pihole_updateGravity.log || cat /var/log/pihole_updateGravity.log' > /etc/cron.d/gravity-on-boot
+    echo '@reboot root PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole updateGravity >/var/log/pihole/pihole_updateGravity.log || cat /var/log/pihole/pihole_updateGravity.log' > /etc/cron.d/gravity-on-boot
 else
     echo "  Skipping Gravity Database Update."
     [ ! -e /etc/cron.d/gravity-on-boot ] || rm /etc/cron.d/gravity-on-boot &>/dev/null

--- a/s6/debian-root/etc/services.d/pihole-FTL/run
+++ b/s6/debian-root/etc/services.d/pihole-FTL/run
@@ -41,5 +41,5 @@ capsh --inh=${CAP_STR:1} --addamb=${CAP_STR:1} --user=$DNSMASQ_USER --keep=1 -- 
 
 # Notes on above:
 # - DNSMASQ_USER default of pihole is in Dockerfile & can be overwritten by runtime container env
-# - /var/log/pihole*.log has FTL's output that no-daemon would normally print in FG too
+# - /var/log/pihole/pihole*.log has FTL's output that no-daemon would normally print in FG too
 #   prevent duplicating it in docker logs by sending to dev null

--- a/s6/debian-root/etc/services.d/pihole-FTL/run
+++ b/s6/debian-root/etc/services.d/pihole-FTL/run
@@ -9,13 +9,13 @@ rm /run/pihole/FTL.sock 2> /dev/null
 mkdir -pm 0755 /run/pihole
 [[ ! -f /run/pihole-FTL.pid ]] && install /dev/null /run/pihole-FTL.pid
 [[ ! -f /run/pihole-FTL.port ]] && install /dev/null /run/pihole-FTL.port
-[[ ! -f /var/log/pihole-FTL.log ]] && install /dev/null /var/log/pihole-FTL.log
-[[ ! -f /var/log/pihole.log ]] && install /dev/null /var/log/pihole.log
+[[ ! -f /var/log/pihole/pihole-FTL.log ]] && install /dev/null /var/log/pihole/pihole-FTL.log
+[[ ! -f /var/log/pihole/pihole.log ]] && install /dev/null /var/log/pihole/pihole.log
 [[ ! -f /etc/pihole/dhcp.leases ]] && install /dev/null /etc/pihole/dhcp.leases
 
 # Ensure that permissions are set so that pihole-FTL can edit all necessary files
-chown pihole:pihole /run/pihole-FTL.pid /run/pihole-FTL.port /var/log/pihole-FTL.log /var/log/pihole.log /etc/pihole/dhcp.leases /run/pihole /etc/pihole
-chmod 0644 /run/pihole-FTL.pid /run/pihole-FTL.port /var/log/pihole-FTL.log /var/log/pihole.log /etc/pihole/dhcp.leases
+chown pihole:pihole /run/pihole-FTL.pid /run/pihole-FTL.port /var/log/pihole/pihole-FTL.log /var/log/pihole/pihole.log /etc/pihole/dhcp.leases /run/pihole /etc/pihole
+chmod 0644 /run/pihole-FTL.pid /run/pihole-FTL.port /var/log/pihole/pihole-FTL.log /var/log/pihole/pihole.log /etc/pihole/dhcp.leases
 
 # Ensure that permissions are set so that pihole-FTL can edit the files. We ignore errors as the file may not (yet) exist
 chmod -f 0644 /etc/pihole/macvendor.db
@@ -23,6 +23,18 @@ chmod -f 0644 /etc/pihole/macvendor.db
 chown -f pihole:pihole /etc/pihole/pihole-FTL.db /etc/pihole/gravity.db /etc/pihole/macvendor.db
 # Chown database file permissions so that the pihole group (web interface) can edit the file. We ignore errors as the files may not (yet) exist
 chmod -f 0664 /etc/pihole/pihole-FTL.db
+
+# Backward compatibility for user-scripts that still expect log files in /var/log instead of /var/log/pihole/
+# Should be removed with Pi-hole v6.0
+if [ ! -f /var/log/pihole.log ]; then
+    ln -s /var/log/pihole/pihole.log /var/log/pihole.log
+    chown -h pihole:pihole /var/log/pihole.log
+
+fi
+if [ ! -f /var/log/pihole-FTL.log ]; then
+    ln -s /var/log/pihole/pihole-FTL.log /var/log/pihole-FTL.log
+    chown -h pihole:pihole /var/log/pihole-FTL.log
+fi
 
 # Call capsh with the detected capabilities
 capsh --inh=${CAP_STR:1} --addamb=${CAP_STR:1} --user=$DNSMASQ_USER --keep=1 -- -c "/usr/bin/pihole-FTL $FTL_CMD >/dev/null 2>&1" 


### PR DESCRIPTION
Relocates Pi-hole log files to `/var/log/pihole/` , which mimics changes made to core's FTL service wrapper