### PR TITLE
set NAMESERVER on startup if PH_NAMESERVER is set

### DIFF
--- a/s6/debian-root/etc/cont-init.d/20-start.sh
+++ b/s6/debian-root/etc/cont-init.d/20-start.sh
@@ -7,6 +7,10 @@ if [ "${PH_VERBOSE:-0}" -gt 0 ] ; then
     bashCmd='bash -e -x'
 fi
 
+if [ "${PH_NAMESERVER:-0}" -gt 0 ] ; then
+    echo nameserver ${PH_NAMESERVER} > /etc/resolv.conf
+fi
+
 $bashCmd /start.sh
 # Gotta go fast, no time for gravity
 if [ -n "$PYTEST" ]; then


### PR DESCRIPTION
Set the name server IP if defined in PH_NAMESERVER environment

## Description

Not in every case it is possible to set the DNS at start of the docker image. In my case Im using snap and I can't set the dns on startup. In this case pinhole do not start up because name server entry is 127.0.0.1 by default.

On startup add --env PH_NAMESERVER=<ip>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

At the moment for every new version of PI Hole Container I need to edit the start file and set the name server manually. This change will fix this.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Tetsed on my qnap container station.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
