### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ services:
       - './etc-pihole:/etc/pihole'
       - './etc-dnsmasq.d:/etc/dnsmasq.d'    
     #   https://github.com/pi-hole/docker-pi-hole#note-on-capabilities
+    dns:
+      - 127.0.0.1
+      - 1.1.1.1
     cap_add:
       - NET_ADMIN # Required if you are using Pi-hole as your DHCP server, else not needed
     restart: unless-stopped


### PR DESCRIPTION
Adding the dns option in the docker-compose.yml. Without it, lighttpd won't start correctly.

Signed-off-by: Merire <44064845+Merire@users.noreply.github.com>


<!--- Provide a general summary of your changes in the Title above -->

## Description
simple option added in the docker-compose.yml. Also mentioned in the bug here : https://github.com/pi-hole/docker-pi-hole/issues/490

## Motivation and Context
Searched for a long time why the admin interface was not working. Turns out lighttpd was not started correctly. Started it, still was not working as intended. 
Solved the issue by adding 
> dns:
>      - 127.0.0.1
>     - 1.1.1.1

in the docker-compose.yml. 

It was not mentioned in the readme, so I made a pull request. 

## How Has This Been Tested?
Works on my raspberry pi 4. Also documented here https://github.com/pi-hole/docker-pi-hole/issues/490

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
