### PR TITLE
Rename PH_TEST to SKIP_INSTALL

### DIFF
--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -39,7 +39,7 @@ fix_capabilities() {
 
 prepare_configs() {
     # Done in /start.sh, don't do twice
-    PH_TEST=true . "${PIHOLE_INSTALL}"
+    SKIP_INSTALL=true . "${PIHOLE_INSTALL}"
     # Set Debian webserver variables for installConfigs
     LIGHTTPD_USER="www-data"
     LIGHTTPD_GROUP="www-data"

--- a/start.sh
+++ b/start.sh
@@ -54,8 +54,8 @@ export adlistFile='/etc/pihole/adlists.list'
 # Ensure we have all functions available to update our configurations
 . /opt/pihole/webpage.sh
 
-# PH_TEST prevents the install from actually running (someone should rename that)
-PH_TEST=true . "${PIHOLE_INSTALL}"
+# SKIP_INSTALL prevents the install from actually running
+SKIP_INSTALL=true . "${PIHOLE_INSTALL}"
 
 echo " ::: Starting docker specific checks & setup for docker pihole/pihole"
 


### PR DESCRIPTION
Rename the variable `PH_TEST` to something meaningful like `SKIP_INSTALL`.
It was waiting for it's renaming since 6 years. 
Needs https://github.com/pi-hole/pi-hole/pull/4788
