### PR TITLE
download macvendor.db on container start if it is missing

### DIFF
--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -69,6 +69,12 @@ prepare_configs() {
     if [[ -e "${setupVars}" ]]; then
         cp -f "${setupVars}" "${setupVars}.update.bak"
     fi
+
+    #If the user has volume mounted /etc/pihole, then macvendor.db may be missing. See: https://github.com/pi-hole/docker-pi-hole/issues/1137
+    if [[ ! -f "/etc/pihole/macvendor.db" ]]; then
+        echo "Downloading missing macvendor.db"
+        curl -sSL "https://ftl.pi-hole.net/macvendor.db" -o "/etc/pihole/macvendor.db" || true
+    fi
 }
 
 validate_env() {


### PR DESCRIPTION
Addresses https://github.com/pi-hole/docker-pi-hole/issues/1137.

In case of a user mounting `/etc/pihole` to their host, this redownloads the `macvendor.db` file used by the network table.

Ordinarily this is downloaded during the original install process (and, in fact, is present in the image), but obviously overriding that directory will clear it out. There is no other mechanism in the base install that re-acquires a missing `macvendor.db`, as this is not ordinarily a problem on a bare metal install, and the file doesn't change an awful lot