### PR TITLE
Ensure creation of all needed Pi-hole files in /etc/pihole on container startup

### DIFF
--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -45,6 +45,7 @@ prepare_configs() {
     LIGHTTPD_GROUP="www-data"
     LIGHTTPD_CFG="lighttpd.conf.debian"
     installConfigs
+    installLogrotate || true #installLogRotate can return 2 or 3, but we are still OK to continue in that case
 
     if [ ! -f "${setupVars}" ]; then
         install -m 644 /dev/null "${setupVars}"
@@ -70,11 +71,11 @@ prepare_configs() {
         cp -f "${setupVars}" "${setupVars}.update.bak"
     fi
 
-    #If the user has volume mounted /etc/pihole, then macvendor.db may be missing. See: https://github.com/pi-hole/docker-pi-hole/issues/1137
-    if [[ ! -f "/etc/pihole/macvendor.db" ]]; then
-        echo "Downloading missing macvendor.db"
-        curl -sSL "https://ftl.pi-hole.net/macvendor.db" -o "/etc/pihole/macvendor.db" || true
+    # Remove any existing macvendor.db and replace it with a symblink to the one moved to the root directory (see install.sh)
+    if [[ -f "/etc/pihole/macvendor.db" ]]; then
+        rm /etc/pihole/macvendor.db
     fi
+    ln -s /macvendor.db /etc/pihole/macvendor.db
 }
 
 validate_env() {

--- a/install.sh
+++ b/install.sh
@@ -76,6 +76,12 @@ sed -i $'s/)\s*uninstallFunc/) unsupportedFunc/g' /usr/local/bin/pihole
 # pihole -r / pihole reconfigure
 sed -i $'s/)\s*reconfigurePiholeFunc/) unsupportedFunc/g' /usr/local/bin/pihole
 
+# Move macvendor.db to root dir and symlink it back into /etc/pihole. See https://github.com/pi-hole/docker-pi-hole/issues/1137
+# If user goes on to bind monunt this directory to their host, then we can easily ensure macvendor.db is the latest
+# (it is otherwise only updated when FTL is updated, which doesn't happen as part of the normal course of running this image)
+mv /etc/pihole/macvendor.db /macvendor.db
+ln -s /macvendor.db /etc/pihole/macvendor.db
+
 if [ ! -f /.piholeFirstBoot ]; then
   touch /.piholeFirstBoot
 fi


### PR DESCRIPTION
Instead of downloading macvendor.db only when it does not exist, move the initially installed version to root and symlink to it to ensure it is always up to date.
Run installLogRotate from basic-install.sh to include the logrotate config in /etc/pihole (base image now includes logrotate)

Additional info: #1137, #153