### PR TITLE
Changed URL from https to http

### DIFF
--- a/docker_run.sh
+++ b/docker_run.sh
@@ -25,7 +25,7 @@ printf 'Starting up pihole container '
 for i in $(seq 1 20); do
     if [ "$(docker inspect -f "{{.State.Health.Status}}" pihole)" == "healthy" ] ; then
         printf ' OK'
-        echo -e "\n$(docker logs pihole 2> /dev/null | grep 'password:') for your pi-hole: https://${IP}/admin/"
+        echo -e "\n$(docker logs pihole 2> /dev/null | grep 'password:') for your pi-hole: http://${IP}/admin/"
         exit 0
     else
         sleep 3


### PR DESCRIPTION
That's just a detail obviously, but I hope this little fix helps anyway.
Thanks a lot to everyone working on Pi-hole for your awesome work though :) 

## Description

Changed URL's protocol of the Pi-hole web interface from https to http.
The script makes the pi-hole instance listening on the 80 (http) port, thus the URL should be "http://${IP}/admin/" (not https).

## Motivation and Context

This change aims to solve the fact that the script gives a wrong URL to the user when printing the random password to access the web interface.

## How Has This Been Tested?

Tested on an Arch-Linux VM that runs docker.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.