### PR TITLE
Add missing backticks to Experimental Variables section on README for consistent markdown 

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,12 +145,12 @@ There are other environment variables if you want to customize various things in
 ### Experimental Variables
 | Variable | Default | Value | Description |
 | -------- | ------- | ----- | ---------- |
-| `DNSMASQ_USER` | unset | `<pihole\|root>` | Allows changing the user that FTLDNS runs as. Default: `pihole`
-| PIHOLE_UID | debian system value | Number | Overrides image's default pihole user id to match a host user id  |
-| PIHOLE_GID | debian system value | Number | Overrides image's default pihole group id to match a host group id |
-| WEB_UID | debian system value | Number | Overrides image's default www-data user id to match a host user id |
-| WEB_GID | debian system value | Number | Overrides image's default www-data group id to match a host group id |
-| WEBLOGS_STDOUT | 0 | 0&vert;1 | 0 logs to defined files, 1 redirect access and error logs to stdout |
+| `DNSMASQ_USER` | unset | `<pihole\|root>` | Allows changing the user that FTLDNS runs as. Default: `pihole`|
+| `PIHOLE_UID` | debian system value | Number | Overrides image's default pihole user id to match a host user id  |
+| `PIHOLE_GID` | debian system value | Number | Overrides image's default pihole group id to match a host group id |
+| `WEB_UID` | debian system value | Number | Overrides image's default www-data user id to match a host user id |
+| `WEB_GID` | debian system value | Number | Overrides image's default www-data group id to match a host group id |
+| `WEBLOGS_STDOUT` | 0 | 0&vert;1 | 0 logs to defined files, 1 redirect access and error logs to stdout |
 
 ## Deprecated environment variables:
 While these may still work, they are likely to be removed in a future version. Where applicable, alternative variable names are indicated. Please review the table above for usage of the alternative variables


### PR DESCRIPTION
## Description
Several environment variables in "Experimental Variables" are missing markdown backticks. 

## Motivation and Context
Consistent markdown

## How Has This Been Tested?
Reviewed markdown changes visually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
