### PR TITLE
Don't run full test and build when only the README file is changed

### DIFF
--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -3,9 +3,13 @@ on:
   schedule:
     - cron: '0 2 * * *'
   push:
+    paths-ignore:
+      - 'README.md'
     branches:
       - dev
   pull_request:
+    paths-ignore:
+      - 'README.md'
   release:
     types: [published]
 


### PR DESCRIPTION
Meta PR. We don't need to build and test the whole image when only changes to the README are made. 

Not sure how this will play with a `Required` check