### PR TITLE
Fix issues with Podman and S6 overlay

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -9,7 +9,7 @@ ENV S6_OVERLAY_VERSION v3.1.1.2
 COPY ./scripts/install.sh /usr/local/bin/install.sh
 ENV PIHOLE_INSTALL /etc/.pihole/automated\ install/basic-install.sh
 
-ENTRYPOINT [ "/init" ]
+ENTRYPOINT [ "/s6-init" ]
 
 COPY s6/debian-root /
 COPY s6/service /usr/local/bin/service

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -39,6 +39,12 @@ detect_arch
 curl -L -s "https://github.com/just-containers/s6-overlay/releases/download/${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz" | tar Jxpf - -C /
 curl -L -s "https://github.com/just-containers/s6-overlay/releases/download/${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}.tar.xz" | tar Jxpf - -C /
 
+# IMPORTANT: #########################################################################
+# Move /init somewhere else to prevent issues with podman/RHEL                       #
+# See: https://github.com/pi-hole/docker-pi-hole/issues/1176#issuecomment-1227587045 #
+mv /init /s6-init                                                                    #
+######################################################################################
+
 # Preseed variables to assist with using --unattended install
 {
   echo "PIHOLE_INTERFACE=eth0"


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Should fix : https://github.com/pi-hole/docker-pi-hole/issues/1176

TL;DR:

Before I updated the version of `s6-overlay` in the container, there was [this line](https://github.com/pi-hole/docker-pi-hole/blob/2022.07.1/install.sh#L38) that moved `/init` to `/s6-init`, and the `entrypoint` was set to `/s6-init`.

I've just tested reverting this change (here: https://github.com/pi-hole/docker-pi-hole/commit/18360d162ad69cdab9d93c33099637a200cb8f2a), and pushed a new image with the `:exp` tag

Can you folk that are running into issues with `podman` please try `pihole/pihole:exp` and report back? Thanks!

(From a very brief test on my UDM running podman, it at least starts the container)

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_