### PR TITLE
Remove the email function

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ There are other environment variables if you want to customize various things in
 
 | Variable | Default | Value | Description |
 | -------- | ------- | ----- | ---------- |
-| `ADMIN_EMAIL` | unset | email address | Set an administrative contact address for the Block Page |
 | `PIHOLE_DNS_` |  `8.8.8.8;8.8.4.4` | IPs delimited by `;` | Upstream DNS server(s) for Pi-hole to forward queries to, separated by a semicolon <br/> (supports non-standard ports with `#[port number]`) e.g `127.0.0.1#5053;8.8.8.8;8.8.4.4` <br/> (supports [Docker service names and links](https://docs.docker.com/compose/networking/) instead of IPs) e.g `upstream0;upstream1` where `upstream0` and `upstream1` are the service names of or links to docker services <br/> Note: The existence of this environment variable assumes this as the _sole_ management of upstream DNS. Upstream DNS added via the web interface will be overwritten on container restart/recreation |
 | `DNSSEC` | `false` | `<"true"\|"false">` | Enable DNSSEC support |
 | `DNS_BOGUS_PRIV` | `true` |`<"true"\|"false">`| Never forward reverse lookups for private ranges |

--- a/src/s6/debian-root/usr/local/bin/_startup.sh
+++ b/src/s6/debian-root/usr/local/bin/_startup.sh
@@ -43,7 +43,6 @@ setup_lighttpd_bind
 
 # Misc Setup
 # ===========================
-setup_admin_email
 setup_blocklists
 
 # FTL setup

--- a/src/s6/debian-root/usr/local/bin/bash_functions.sh
+++ b/src/s6/debian-root/usr/local/bin/bash_functions.sh
@@ -524,11 +524,3 @@ setup_web_layout() {
       fi
   fi
 }
-
-setup_admin_email() {
-  local EMAIL="${ADMIN_EMAIL}"
-  # check if var is empty
-  if [[ "$EMAIL" != "" ]] ; then
-      pihole -a -e "$EMAIL"
-  fi
-}


### PR DESCRIPTION


## Description
Admin email function removed

## Motivation and Context
It was removed from pi-hole in 5.12 by this PR https://github.com/pi-hole/pi-hole/pull/4870

## How Has This Been Tested?
No test done, it should be pretty straightforward

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
