### PR TITLE
init commit of Pi-hole behind Caddy example

### DIFF
--- a/examples/Caddyfile
+++ b/examples/Caddyfile
@@ -1,0 +1,5 @@
+pihole-dev.lab {
+  tls internal
+  redir / /admin
+  reverse_proxy pihole:8081
+}

--- a/examples/docker-compose-caddy-proxy.yml
+++ b/examples/docker-compose-caddy-proxy.yml
@@ -1,0 +1,66 @@
+version: "3"
+
+services:
+
+  # Caddy example derived from Caddy's own example at https://hub.docker.com/_/caddy
+  caddy:
+    container_name: caddy
+    image: caddy:latest
+    networks:
+      - caddy-net  # Network exclusively for Caddy-proxied containers
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"  # QUIC protocol support: https://www.chromium.org/quic/
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile  # config file on host in same directory as docker-compose.yml for easy editing.
+      #- $PWD/site:/srv  # Only use if you are serving a website behind caddy
+      - caddy_data:/data  # Use docker volumes here bc no need to access these files from host
+      - caddy_config:/config  # Use docker volumes here bc no need to access these files from host
+
+
+  # More info at https://github.com/pi-hole/docker-pi-hole/ and https://docs.pi-hole.net/
+  pihole:
+    depends_on: 
+      - caddy
+    container_name: pihole
+    #dns:  # Optional. Specify desired upstream DNS servers here.
+    #  - 127.0.0.1
+    #  - 9.9.9.9
+    #  - 149.112.112.112
+    image: pihole/pihole:latest
+    networks:
+      - caddy-net  # Need to plug into caddy net to access proxy
+    ports:
+      - "8081/tcp" # Pi-hole web admin interface, proxied through Caddy (configure port in Caddyfile)
+      # Following are NOT proxied through Caddy, bound to host net instead:
+      - "53:53/udp"
+      - "53:53/tcp"
+      - "853:853/tcp" # DNS-over-TLS 
+      #- "67:67/udp" # DHCP, if desired. If not bound to host net you need an mDNS proxy service configured somewhere on host net.
+        # ref: https://docs.pi-hole.net/docker/DHCP/
+    environment:
+      TZ: 'America/New_York' # Supported TZ database names: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#Time_Zone_abbreviations
+      WEBPASSWORD: 'password' # Only used on first boot, change with pihole cli then comment out here.
+    volumes:
+      - './etc-pihole:/etc/pihole'
+      - './etc-dnsmasq.d:/etc/dnsmasq.d'
+      - './etc-lighttpd/external.conf:/etc/lighttpd/external.conf'  # Recommend leave as bind mount for easier editing.
+        # ref for why you may need to change this file: https://docs.pi-hole.net/guides/webserver/caddy/#modifying-lighttpd-configuration
+    #cap_add:  # Uncomment if using Pi-hole as DHCP server
+      # https://github.com/pi-hole/docker-pi-hole#note-on-capabilities
+      #- NET_ADMIN # ONLY required if you are using Pi-hole as your DHCP server, else remove for better security
+    restart: unless-stopped
+
+# ref: https://hub.docker.com/_/caddy
+networks:
+  caddy-net:
+    driver: bridge
+    name: caddy-net
+
+# ref: https://hub.docker.com/_/caddy
+volumes:
+  caddy_data:
+    external: true  # May need to create volume with 'docker volume create caddy_data'
+  caddy_config:


### PR DESCRIPTION


Signed-off-by: William Trelawny <william@trelawny.family>

## Description
- Single docker compose file to spin up a Caddy and a Pi-hole container
- I put plenty of comments in compose file for user ref. Looks kinda
  messy but I figured the more info the better and they can cull out
what they dont need.
- DHCP server is disabled by default in Pi-hole so I disabled the port
  binding and NET_ADMIN capability by default as well, with brief
instructions and refs included.
- Caddy docker compose example ref: https://hub.docker.com/_/caddy
- Pi-hole Caddy config ref: https://docs.pi-hole.net/guides/webserver/caddy/

## Motivation and Context
Gives users a good working starting point if trying to run Pi-hole behind a Caddy reverse proxy.

## How Has This Been Tested?
Tested env:
- Debian 11.4 OS
- Docker v20.10.17
- Docker Compose v2.6.0
- docker-pi-hole container v2022.08.2 ("latest" at time of testing)
- Caddy container v2.5.2 ("latest" at time of testing)

Test command: `docker compose -f docker-compose-caddy-proxy.yml up`

Verified Pi-hole reachable behind proxy via access with external browser.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
