### PR TITLE
S6_ARCH fix for rpi1

### DIFF
--- a/src/s6/debian-root/usr/local/bin/install.sh
+++ b/src/s6/debian-root/usr/local/bin/install.sh
@@ -16,7 +16,7 @@ detect_arch() {
   amd64)
     S6_ARCH="x86_64";;
   armel)
-    S6_ARCH="arm";;
+    S6_ARCH="armhf";;
   armhf)
     S6_ARCH="armhf";;
   arm64)


### PR DESCRIPTION
## Description
Fixes S6_ARCH for rpi1

Signed-off-by: danitorregrosa <danitorregrosa@gmail.com>

## Motivation and Context
Current docker image does not run in rpi1 because s6_overlay arch is wrong, after s6_overlay v3 changes
Resolves #1201

## How Has This Been Tested?
docker build src/

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
