### PR TITLE
Remove references to deprecated `pihole-FTL.port` file

### DIFF
--- a/src/s6/debian-root/etc/s6-overlay/s6-rc.d/pihole-FTL/run
+++ b/src/s6/debian-root/etc/s6-overlay/s6-rc.d/pihole-FTL/run
@@ -11,14 +11,13 @@ rm /run/pihole/FTL.sock 2> /dev/null
 # install /dev/null files to ensure they exist (create if non-existing, preserve if existing)
 mkdir -pm 0755 /run/pihole /var/log/pihole
 [[ ! -f /run/pihole-FTL.pid ]] && install /dev/null /run/pihole-FTL.pid
-[[ ! -f /run/pihole-FTL.port ]] && install /dev/null /run/pihole-FTL.port
 [[ ! -f /var/log/pihole/FTL.log ]] && install /dev/null /var/log/pihole/FTL.log
 [[ ! -f /var/log/pihole/pihole.log ]] && install /dev/null /var/log/pihole/pihole.log
 [[ ! -f /etc/pihole/dhcp.leases ]] && install /dev/null /etc/pihole/dhcp.leases
 
 # Ensure that permissions are set so that pihole-FTL can edit all necessary files
-chown pihole:pihole /run/pihole-FTL.pid /run/pihole-FTL.port /var/log/pihole/FTL.log /var/log/pihole/pihole.log /etc/pihole/dhcp.leases /run/pihole /etc/pihole
-chmod 0644 /run/pihole-FTL.pid /run/pihole-FTL.port /var/log/pihole/FTL.log /var/log/pihole/pihole.log /etc/pihole/dhcp.leases
+chown pihole:pihole /run/pihole-FTL.pid /var/log/pihole/FTL.log /var/log/pihole/pihole.log /etc/pihole/dhcp.leases /run/pihole /etc/pihole
+chmod 0644 /run/pihole-FTL.pid /var/log/pihole/FTL.log /var/log/pihole/pihole.log /etc/pihole/dhcp.leases
 
 # Ensure that permissions are set so that pihole-FTL can edit the files. We ignore errors as the file may not (yet) exist
 chmod -f 0644 /etc/pihole/macvendor.db


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Title. See https://github.com/pi-hole/FTL/pull/1445
---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_