### PR TITLE
Added Dockerfile for local usage.

### DIFF
--- a/src/Dockerfile_local
+++ b/src/Dockerfile_local
@@ -1,13 +1,25 @@
 ARG PIHOLE_BASE
-FROM "${PIHOLE_BASE:-ghcr.io/pi-hole/docker-pi-hole-base:bullseye-slim}"
+FROM ubuntu:latest
+
+ENV TZ=Europe/Berlin
+ENV WEBPASSWORD=changeme
+
+
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt update -y && apt upgrade -y && apt install php curl -y
 
 ARG PIHOLE_DOCKER_TAG
 RUN echo "${PIHOLE_DOCKER_TAG}" > /pihole.docker.tag
 
 ENTRYPOINT [ "/s6-init" ]
 
+ # etc and usr are now in /
 COPY s6/debian-root /
+# file is in /usr/local/bin/service
 COPY s6/service /usr/local/bin/service
+
+WORKDIR /usr/local/bin
 
 RUN bash -ex install.sh 2>&1 && \
     rm -rf /var/cache/apt/archives /var/lib/apt/lists/*


### PR DESCRIPTION
This pr solves multiple issues:
- As stated here [Discourse Pihole](https://discourse.pi-hole.net/t/how-to-build-a-recent-version-of-docker-pihole-locally/59074/3) a local Dockerfile is currently not present. This local dockerfile can be executed by every user with ``docker build -t local_pihole -f Dockerfile_local .``
- Decrease vulnerabilities from critical to medium, decrease number of vulnerabilities by 135.

The current build with the latest debian image has 178 known vulnerabilities:
- 11 critical
- 32 high
- 43 middle
- 92 low 
![image](https://user-images.githubusercontent.com/40429738/200931766-33a02d1c-41d9-4140-ad55-107d1dd57ff8.png)

The local image is based on Ubuntu and has 43 vulnerabilties
- 8 middle
- 35 low
![image](https://user-images.githubusercontent.com/40429738/200933205-b875f736-03a4-4e40-97fd-2452b3c0e75a.png)
