### PR TITLE
Fix command example to be docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ services:
       - NET_ADMIN # Required if you are using Pi-hole as your DHCP server, else not needed
     restart: unless-stopped
 ```
-2. Run `docker compose -f docker-compose.yml up -d` to build and start pi-hole
+2. Run `docker-compose -f docker-compose.yml up -d` to build and start pi-hole
 3. Use the Pi-hole web UI to change the DNS settings *Interface listening behavior* to "Listen on all interfaces, permit all origins", if using Docker's default `bridge` network setting. (This can also be achieved by setting the environment variable `DNSMASQ_LISTENING` to `all`)
 
 [Here is an equivalent docker run script](https://github.com/pi-hole/docker-pi-hole/blob/master/examples/docker_run.sh).


### PR DESCRIPTION
The example says `docker compose` which I don't think is correct

Signed-off-by: Phil Verghese <philverghese@users.noreply.github.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
The command given in the quick start example uses `docker` instead of `docker-compose`

## Motivation and Context
Give a command line that works

## How Has This Been Tested?
Ran locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
