### PR TITLE
Remove unneeded variable reference in FTL run script

### DIFF
--- a/src/s6/debian-root/etc/s6-overlay/s6-rc.d/pihole-FTL/run
+++ b/src/s6/debian-root/etc/s6-overlay/s6-rc.d/pihole-FTL/run
@@ -38,8 +38,7 @@ if [ ! -f /var/log/pihole-FTL.log ]; then
     chown -h pihole:pihole /var/log/pihole-FTL.log
 fi
 
-# Call capsh with the detected capabilities
-capsh --inh=${CAP_STR:1} --addamb=${CAP_STR:1} --user=$DNSMASQ_USER --keep=1 -- -c "/usr/bin/pihole-FTL $FTL_CMD >/dev/null 2>&1"
+capsh --user=$DNSMASQ_USER --keep=1 -- -c "/usr/bin/pihole-FTL $FTL_CMD >/dev/null 2>&1"
 
 # Notes on above:
 # - DNSMASQ_USER default of pihole is in Dockerfile & can be overwritten by runtime container env


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Noted that `CAP_STR` is empty since https://github.com/pi-hole/docker-pi-hole/commit/776bac7b90516fde4dea084554028efd95d43321

Adding in the following on a local build proved it:

```
echo "-----------------"
echo ${CAP_STR:1}
echo "-----------------"
```

Outputs:

```
pihole  | -----------------
pihole  | 
pihole  | -----------------
```

However, there shouldn't be anything that needs fixing here as the caps are already set further up the script

```
pihole  |   [i] Applying the following caps to pihole-FTL:
pihole  |         * CAP_CHOWN
pihole  |         * CAP_NET_BIND_SERVICE
pihole  |         * CAP_NET_RAW
pihole  |         * CAP_NET_ADMIN
```

To note: Currently we are calling:

```
--inh=${CAP_STR:1} --addamb=${CAP_STR:1}
```

or - actually

```
--inh= --addamb=
```

And nobody has complained it's not working... The conversation around moving the stuff back out into `bash_function.sh` happened here: https://github.com/pi-hole/docker-pi-hole/issues/1175#issuecomment-1226284993

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_