### PR TITLE
Changed the build and compose command syntax in README.md to be functional

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ services:
       - NET_ADMIN # Required if you are using Pi-hole as your DHCP server, else not needed
     restart: unless-stopped
 ```
-2. Run `docker compose -f docker-compose.yml up -d` to build and start pi-hole
+2. Run `docker-compose -f docker-compose.yml up -d` to build and start pi-hole
 3. Use the Pi-hole web UI to change the DNS settings *Interface listening behavior* to "Listen on all interfaces, permit all origins", if using Docker's default `bridge` network setting. (This can also be achieved by setting the environment variable `DNSMASQ_LISTENING` to `all`)
 
 [Here is an equivalent docker run script](https://github.com/pi-hole/docker-pi-hole/blob/master/examples/docker_run.sh).


### PR DESCRIPTION
eral summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The readme had `docker compose -f docker-compose.yml up -d`, which references the wrong binary. It should be updated to reference `docker-compose`, a different utility than `docker`, and the correct binary to complete the operation at hand.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change was added to make the example command for building and deploying functional.  Prior to this change the command would fail, because the syntax was meant for the `docker-compose` binary and does not work with the `docker` binary
## How Has This Been Tested?
This was tested using the preview feature and by running the command in a Debian test environment with `docker` and `docker-compose installed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.

Signed-off-by: zleyyij <75810274+zleyyij@users.noreply.github.com>