### PR TITLE
Add action to close stale PR

### DIFF
--- a/.github/workflows/stale_pr.yml
+++ b/.github/workflows/stale_pr.yml
@@ -1,7 +1,7 @@
 name: Close stale PR
 # This action will add a `stale` label and close immediately every PR that meets the following conditions:
 #   - it is already marked with "merge conflict" label
-#   - the "merge conflict" label was added more than 30 days before.
+#   - there was no update/comment on the PR in the last 30 days.
 
 on:
   schedule:
@@ -20,9 +20,11 @@ jobs:
       - uses: actions/stale@v7.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          # Do not mark a PR as stale
+          # Do not automatically mark PR/issue as stale
           days-before-stale: -1
+          # Override 'days-before-stale' for PR only
           days-before-pr-stale: 30
+          # Close PRs immediately, after marking them 'stale'
           days-before-pr-close: 0
           # only run the action on merge conflict PR
           any-of-labels: 'Merge Conflict'

--- a/.github/workflows/stale_pr.yml
+++ b/.github/workflows/stale_pr.yml
@@ -1,0 +1,33 @@
+name: Close stale PR
+# This action will add a `stale` label and close immediately every PR that meets the following conditions:
+#   - it is already marked with "merge conflict" label
+#   - the "merge conflict" label was added more than 30 days before.
+
+on:
+  schedule:
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/stale@v7.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # Do not mark a PR as stale
+          days-before-stale: -1
+          days-before-pr-stale: 30
+          days-before-pr-close: 0
+          # only run the action on merge conflict PR
+          any-of-labels: 'Merge Conflict'
+          exempt-pr-labels: 'internal,never-stale,ON HOLD,in progress'
+          exempt-all-pr-assignees: true
+          operations-per-run: 300
+          stale-pr-message: ''
+          close-pr-message: 'Existing merge conflicts have not been addressed. This PR is considered abandoned.'


### PR DESCRIPTION
### What does this PR aim to accomplish?

Add an action to verify every PR marked with `Merge Conflict` label and automatically close it.

### How the action works 

The action will close (actually, mark as stale and close immediately) any PR that have been labeled with 'merge conflict' 30 (or more) days earlier. This action will run once a day.

The action will ignore:
- every PR without `Merge Conflict` label;
- every PR with `internal`, `never-stale`, `ON HOLD`, `WIP` labels;
- draft PR.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
