### PR TITLE
lighttpd does not like it if VIRTUAL_HOST and FTLCONF_LOCAL_IPV4 are duplicate values...

### DIFF
--- a/src/s6/debian-root/usr/local/bin/bash_functions.sh
+++ b/src/s6/debian-root/usr/local/bin/bash_functions.sh
@@ -349,10 +349,10 @@ setup_lighttpd_bind() {
 
 setup_web_php_env() {
     local config_file
-    config_file="/etc/lighttpd/conf-enabled/15-pihole-admin.conf"
-    # if the environment variable VIRTUAL_HOST is not set, or is empty, then set it to the IP address of the container
+    config_file="/etc/lighttpd/conf-available/15-pihole-admin.conf"
+    # if the environment variable VIRTUAL_HOST is not set, or is empty, then set it to the hostname of the container
     if [ -z "${VIRTUAL_HOST}" ] || [ "${VIRTUAL_HOST}" == "" ]; then
-        VIRTUAL_HOST="${FTLCONF_LOCAL_IPV4}"
+        VIRTUAL_HOST="${HOSTNAME}"
     fi
 
     for config_var in "VIRTUAL_HOST" "CORS_HOSTS" "PHP_ERROR_LOG" "PIHOLE_DOCKER_TAG" "TZ"; do


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Aims to fix: https://github.com/pi-hole/docker-pi-hole/issues/1279

Before, if `VIRTUAL_HOST` was not set, then the code would set it to the same value as `FTLCONF_LOCAL_IPV4` - this is no bueno because then we end up with a duplicate value in the lighttpd config, which causes it to correctly fall over.

I did not see this on my own machine because I have both `FTLCONF_LOCAL_IPV4` and `VIRTUAL_HOST` set independently in my container config. Will I ever learn that "Works on my machine" isn't a valid excuse? Probably not... It's all part of the fun!

This also reverts the change made in the previous PR, as that was a false alarm. The file is symlinked by the install script 

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_