### PR TITLE
Allow for empty strings to be passed into FTLCONF_ environment variables

### DIFF
--- a/src/s6/debian-root/usr/local/bin/bash_functions.sh
+++ b/src/s6/debian-root/usr/local/bin/bash_functions.sh
@@ -206,7 +206,7 @@ apply_FTL_Configs_From_Env(){
     # Get all exported environment variables starting with FTLCONF_ as a prefix and call the changeFTLsetting
     # function with the environment variable's suffix as the key. This allows applying any pihole-FTL.conf
     # setting defined here: https://docs.pi-hole.net/ftldns/configfile/
-    declare -px | grep FTLCONF_ | sed -E 's/declare -x FTLCONF_([^=]+)=\"(.+)\"/\1 \2/' | while read -r name value
+    declare -px | grep FTLCONF_ | sed -E 's/declare -x FTLCONF_([^=]+)=\"(|.+)\"/\1 \2/' | while read -r name value
     do
         echo "  [i] Applying pihole-FTL.conf setting $name=$value"
         changeFTLsetting "$name" "$value"


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

In order to set FTL's `DBFILE` value to empty, one has to pass in the variable as in as `FTLCONF_DBFILE: ""`, however this was parsed wrong by the `sed` command which was expected one or more chars between the `"`s.  

See https://discourse.pi-hole.net/t/installing-a-pi-hole-while-reducing-the-writing-on-the-sd-card/60519/11?u=promofaux

This fixes it by allowing the value between `"`s to also be empty

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_