### PR TITLE
Add support for changing admin bind address indepentendly of $FTLCONF_LOCAL_IPV4

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ There are other environment variables if you want to customize various things in
 | -------- | ------- | ----- | ---------- |
 | `TZ` | UTC | `<Timezone>` | Set your [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) to make sure logs rotate at local midnight instead of at UTC midnight.
 | `WEBPASSWORD` | random | `<Admin password>` | http://pi.hole/admin password. Run `docker logs pihole \| grep random` to find your random pass.
-| `FTLCONF_LOCAL_IPV4` | unset | `<Host's IP>` | Set to your server's LAN IP, used by web block modes and lighttpd bind address.
+| `FTLCONF_LOCAL_IPV4` | unset | `<Host's IP>` | Set to your server's LAN IP, used by web block modes.
 
 ### Optional Variables
 
@@ -132,6 +132,7 @@ There are other environment variables if you want to customize various things in
 | `INTERFACE` | unset | `<NIC>` | The default works fine with our basic example docker run commands.  If you're trying to use DHCP with `--net host` mode then you may have to customize this or DNSMASQ_LISTENING.
 | `DNSMASQ_LISTENING` | unset | `<local\|all\|single>` | `local` listens on all local subnets, `all` permits listening on internet origin subnets in addition to local, `single` listens only on the interface specified.
 | `WEB_PORT` | unset | `<PORT>` | **This will break the 'webpage blocked' functionality of Pi-hole** however it may help advanced setups like those running synology or `--net=host` docker argument.  This guide explains how to restore webpage blocked functionality using a linux router DNAT rule: [Alternative Synology installation method](https://discourse.pi-hole.net/t/alternative-synology-installation-method/5454?u=diginc)
+| `WEB_BIND_ADDR` | unset | `<IP>` | Lighttpd's bind address. If left unset lighttpd will bind to every interface, except when running in host networking mode where it will use `FTLCONF_LOCAL_IPV4` instead.
 | `SKIPGRAVITYONBOOT` | unset | `<unset\|1>` | Use this option to skip updating the Gravity Database when booting up the container.  By default this environment variable is not set so the Gravity Database will be updated when the container starts up.  Setting this environment variable to 1 (or anything) will cause the Gravity Database to not be updated when container starts up.
 | `CORS_HOSTS` | unset | `<FQDNs delimited by ,>` | List of domains/subdomains on which CORS is allowed. Wildcards are not supported. Eg: `CORS_HOSTS: domain.com,home.domain.com,www.domain.com`.
 | `CUSTOM_CACHE_SIZE` | `10000` | Number | Set the cache size for dnsmasq. Useful for increasing the default cache size or to set it to 0. Note that when `DNSSEC` is "true", then this setting is ignored.

--- a/src/s6/debian-root/usr/local/bin/bash_functions.sh
+++ b/src/s6/debian-root/usr/local/bin/bash_functions.sh
@@ -399,7 +399,7 @@ setup_web_port() {
         return
     fi
     echo "  [i] Custom WEB_PORT set to $web_port"
-    echo "  [i] Without proper router DNAT forwarding to $FTLCONF_LOCAL_IPV4:$web_port, you may not get any blocked websites on ads"
+    echo "  [i] Without proper router DNAT forwarding to ${WEB_BIND_ADDR:-$FTLCONF_LOCAL_IPV4}:$web_port, you may not get any blocked websites on ads"
 
     # Update lighttpd's port
     sed -i '/server.port\s*=\s*80\s*$/ s/80/'"${WEB_PORT}"'/g' /etc/lighttpd/lighttpd.conf


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As discussed [in the forums](https://discourse.pi-hole.net/t/support-changing-admin-bind-address-to-something-else-than-ftlconf-local-ipv4/60632), this PR adds a new environment variable (`$WEB_BIND_ADDR`) to enable changing lighttpd's bind address separately from `$FTLCONF_LOCAL_IPV4`.

I'm not sure how deprecations are usually handled in this project so I made sure to maintain backward compatibility with the previous behavior discussed in #154 (listening on `$FTLCONF_LOCAL_IPV4` when in host networking). However, this edge case would now be better handled by setting `$WEB_BIND_ADDR` to the desired value. I've added a warning to that effect in the install script, suggesting this behavior will be removed in the future in a breaking change release. Another option would be to introduce the breaking change directly since there is a migration path. Let me know if you'd rather address this change differently.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`$FTLCONF_LOCAL_IPV4` is currently used to represent two different values at once:

- the Pi-hole host's IP (i.e. the result of `dig pi.hole`)
- the bind address of the admin interface

In some situations, these two values are different and the user has to choose between accessing the interface or resolving the Pi-hole host via DNS.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- I wrote additional tests that cover all execution paths in the `setup_lighttpd_bind` function.
- I built the image locally and confirmed lighttpd used the expected bind addresses.

I expect the blast radius of this PR to be fairly minimal so I haven't manually tested other features.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. <- I think so but also haven't found a style guide so I might be off.
- [x] My change requires a change to the documentation. <- I made changes in the README, not sure if we need more.
- [X] I have updated the documentation accordingly.
