### PR TITLE
Ensure that the directory `/run/lighttpd` exists, and that it is owned by www-data

### DIFF
--- a/src/s6/debian-root/usr/local/bin/bash_functions.sh
+++ b/src/s6/debian-root/usr/local/bin/bash_functions.sh
@@ -118,6 +118,11 @@ ensure_basic_configuration() {
         cp /etc/.pihole/advanced/01-pihole.conf /etc/dnsmasq.d/
     fi;
 
+    # Ensure that /run/lighttpd exists for the php socket, and is owned by www-data.
+    # Without this, the web interface will return a 503. Not sure how this used to work, as this was always the directory that was used in previous versions of the image.
+    mkdir -p /run/lighttpd
+    chown www-data:www-data /run/lighttpd
+
     # setup_or_skip_gravity
 }
 


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

A PR on the core repo (https://github.com/pi-hole/pi-hole/pull/5139) changed the path of the PHP socket file from `/tmp` to `/run/lighttpd` (which was always the default path in previous releases)

Somehow this became incompatible with the docker image as `/run/lighttpd` does not exist. Fixes to ensure that the directory always exists before starting lighttpd

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_