### PR TITLE
Configure FTL's MACVENDORDB setting to "/macvendor.db" on startup

### DIFF
--- a/src/s6/debian-root/usr/local/bin/bash_functions.sh
+++ b/src/s6/debian-root/usr/local/bin/bash_functions.sh
@@ -107,11 +107,11 @@ ensure_basic_configuration() {
         cp -f "${setupVars}" "${setupVars}.update.bak"
     fi
 
-    # Remove any existing macvendor.db and replace it with a symblink to the one moved to the root directory (see install.sh)
-    if [[ -f "/etc/pihole/macvendor.db" ]]; then
-        rm /etc/pihole/macvendor.db
+    # If FTLCONF_MACVENDORDB is not set
+    if [[ -z "${FTLCONF_MACVENDORDB:-}" ]]; then
+        # User is not passing in a custom location - so force FTL to use the file we moved to / during the build
+        changeFTLsetting "MACVENDORDB" "/macvendor.db"
     fi
-    ln -s /macvendor.db /etc/pihole/macvendor.db
 
     # When fresh empty directory volumes are used then we need to create this file
     if [ ! -f /etc/dnsmasq.d/01-pihole.conf ] ; then

--- a/src/s6/debian-root/usr/local/bin/install.sh
+++ b/src/s6/debian-root/usr/local/bin/install.sh
@@ -86,11 +86,11 @@ sed -i $'s/)\s*uninstallFunc/) unsupportedFunc/g' /usr/local/bin/pihole
 # pihole -r / pihole reconfigure
 sed -i $'s/)\s*reconfigurePiholeFunc/) unsupportedFunc/g' /usr/local/bin/pihole
 
-# Move macvendor.db to root dir and symlink it back into /etc/pihole. See https://github.com/pi-hole/docker-pi-hole/issues/1137
+# Move macvendor.db to root dir See https://github.com/pi-hole/docker-pi-hole/issues/1137
+# During startup we will change FTL's configuration to point to this file instead of /etc/pihole/macvendor.db
 # If user goes on to bind monunt this directory to their host, then we can easily ensure macvendor.db is the latest
 # (it is otherwise only updated when FTL is updated, which doesn't happen as part of the normal course of running this image)
 mv /etc/pihole/macvendor.db /macvendor.db
-ln -s /macvendor.db /etc/pihole/macvendor.db
 
 if [ ! -f /.piholeFirstBoot ]; then
   touch /.piholeFirstBoot


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Discovered while troubleshooting #1299 (See [comment](https://github.com/pi-hole/docker-pi-hole/issues/1299#issuecomment-1400421003))

We used to symlink this file, however I hadn't realised at the time it was configurable in FTL's config (RTFM, Adam). Setting the config option is performed during the `ensure_basic_configuration` step, and is ignored if a user has passed in their own `FTLCONF_MACVENDORDB` environment variable

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_