### PR TITLE
Replace deprecated variables with the correct ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ While these may still work, they are likely to be removed in a future version. W
 | `CONDITIONAL_FORWARDING_REVERSE` | If conditional forwarding is enabled, set the reverse DNS of the local network router (e.g. `0.168.192.in-addr.arpa`) | `REV_SERVER_CIDR` |
 | `DNS1` | Primary upstream DNS provider, default is google DNS | `PIHOLE_DNS_` |
 | `DNS2` | Secondary upstream DNS provider, default is google DNS, `no` if only one DNS should used | `PIHOLE_DNS_` |
-| `ServerIP` | Set to your server's LAN IP, used by web block modes and lighttpd bind address | `FTLCONF_REPLY_ADDR4` |
-| `ServerIPv6` | **If you have a v6 network** set to your server's LAN IPv6 to block IPv6 ads fully | `FTLCONF_REPLY_ADDR6` |
+| `ServerIP` | Set to your server's LAN IP, used by web block modes and lighttpd bind address | `FTLCONF_LOCAL_IPV4` |
+| `ServerIPv6` | **If you have a v6 network** set to your server's LAN IPv6 to block IPv6 ads fully | `FTLCONF_LOCAL_IPV6` |
 | `FTLCONF_REPLY_ADDR4` | Set to your server's LAN IP, used by web block modes and lighttpd bind address | `FTLCONF_LOCAL_IPV4` |
 | `FTLCONF_REPLY_ADDR6` | **If you have a v6 network** set to your server's LAN IPv6 to block IPv6 ads fully | `FTLCONF_LOCAL_IPV6` |
 

--- a/examples/docker-compose-nginx-proxy.yml
+++ b/examples/docker-compose-nginx-proxy.yml
@@ -30,7 +30,7 @@ services:
     cap_add:
       - NET_ADMIN
     environment:
-      ServerIP: 192.168.41.55
+      FTLCONF_LOCAL_IPV4: 192.168.41.55
       PROXY_LOCATION: pihole
       VIRTUAL_HOST: pihole.yourDomain.lan
       VIRTUAL_PORT: 80


### PR DESCRIPTION
## Description

Fixing a few text and examples using deprecated variables

## Motivation and Context

`ServerIP` and `ServerIP6` were replaced by `FTLCONF_REPLY_ADDR4` and `FTLCONF_REPLY_ADDR6`.
These last 2 items were also deprecated, but all of them still appears on texts and examples.

## Types of changes
- [x] only help and example files were changed 

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
