### PR TITLE
Recreate pi-hole cronjob on container start

### DIFF
--- a/src/s6/debian-root/usr/local/bin/_startup.sh
+++ b/src/s6/debian-root/usr/local/bin/_startup.sh
@@ -43,6 +43,7 @@ setup_lighttpd_bind
 
 # Misc Setup
 # ===========================
+installCron
 setup_blocklists
 
 # FTL setup


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR recreates the pi-hole cronjob on container start.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I stumbled about this:

```
# Pi-hole: Update the ad sources once a week on Sunday at a random time in the
#          early morning. Download any updates from the adlists
#          Squash output to log, then splat the log to stdout on error to allow for
#          standard crontab job error handling.
17 4   * * 7   root    PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole updateGravity >/var/log/pihole/pihole_updateGravity.log || cat /var/log/pihole/pihole_updateGravity.log
```

In a regular pi-hole setup, a random time is generated to run the cron job. When running pi-hole in a container, the time is not random and everyone that uses the same image, will update gravity at the same time.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I checked the cronjob on container start. It has different times on each container start.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
