### PR TITLE
Only allow https for curl

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/* \
     && pip3 install --no-cache-dir -U pip pipenv
 
-RUN curl -L https://github.com/docker/compose/releases/download/2.10.2/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
+RUN curl --proto "=https" -L https://github.com/docker/compose/releases/download/2.10.2/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose
 
 COPY ./cmd.sh /usr/local/bin/


### PR DESCRIPTION
Fixes an error `sonarcloud` raises about allowing insecure redirects. See https://sonarcloud.io/project/security_hotspots?id=pi-hole_docker-pi-hole&pullRequest=1344&resolved=false&types=SECURITY_HOTSPOT&tab=code.

This PR sets the protocol `curl`is allowed to use to `https` only.
