### PR TITLE
shrink image size by ~10%

### DIFF
--- a/src/s6/debian-root/usr/local/bin/install.sh
+++ b/src/s6/debian-root/usr/local/bin/install.sh
@@ -97,6 +97,8 @@ mv /etc/pihole/macvendor.db /macvendor.db
 rm /etc/lighttpd/conf-enabled/99-unconfigured.conf
 ## Remove the default lighttpd placeholder page for good measure
 rm /var/www/html/index.lighttpd.html
+## Remove redundant directories created by the installer to reduce docker image size
+rm -rf /tmp/* /var/www/html/admin/.git* /etc/.pihole/.git*
 
 if [ ! -f /.piholeFirstBoot ]; then
   touch /.piholeFirstBoot

--- a/src/s6/debian-root/usr/local/bin/install.sh
+++ b/src/s6/debian-root/usr/local/bin/install.sh
@@ -98,7 +98,7 @@ rm /etc/lighttpd/conf-enabled/99-unconfigured.conf
 ## Remove the default lighttpd placeholder page for good measure
 rm /var/www/html/index.lighttpd.html
 ## Remove redundant directories created by the installer to reduce docker image size
-rm -rf /tmp/* /var/www/html/admin/.git* /etc/.pihole/.git*
+rm -rf /tmp/*
 
 if [ ! -f /.piholeFirstBoot ]; then
   touch /.piholeFirstBoot


### PR DESCRIPTION
## Description
Remove redundant directories created by the installer to reduce docker image size from **324 MB** to **298 MB**.

## How Has This Been Tested?
`./build-and-test.sh` all tests passed

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
