### PR TITLE
Tweak commands

### DIFF
--- a/src/s6/debian-root/etc/s6-overlay/s6-rc.d/cron/finish
+++ b/src/s6/debian-root/etc/s6-overlay/s6-rc.d/cron/finish
@@ -1,4 +1,4 @@
 #!/command/with-contenv bash
 
 s6-echo "Stopping cron"
-killall -9 cron
+killall --signal 9 cron

--- a/src/s6/debian-root/etc/s6-overlay/s6-rc.d/lighttpd/finish
+++ b/src/s6/debian-root/etc/s6-overlay/s6-rc.d/lighttpd/finish
@@ -3,4 +3,4 @@
 s6-echo "Stopping lighttpd"
 service lighttpd-access-log stop
 service lighttpd-error-log stop
-killall -9 lighttpd
+killall --signal 9 lighttpd

--- a/src/s6/debian-root/etc/s6-overlay/s6-rc.d/pihole-FTL/finish
+++ b/src/s6/debian-root/etc/s6-overlay/s6-rc.d/pihole-FTL/finish
@@ -1,4 +1,4 @@
 #!/command/with-contenv bash
 
 s6-echo "Stopping pihole-FTL"
-killall -15 pihole-FTL
+killall --signal 15 pihole-FTL

--- a/src/s6/debian-root/usr/local/bin/install.sh
+++ b/src/s6/debian-root/usr/local/bin/install.sh
@@ -10,7 +10,7 @@ WEB_LOCAL_REPO=/var/www/html/admin
 setupVars=/etc/pihole/setupVars.conf
 
 detect_arch() {
-  DETECTED_ARCH=$(dpkg --print-architecture)
+  DETECTED_ARCH=$(arch)
   S6_ARCH=$DETECTED_ARCH
   case $DETECTED_ARCH in
   amd64)
@@ -94,9 +94,13 @@ mv /etc/pihole/macvendor.db /macvendor.db
 
 
 ## Remove the default lighttpd unconfigured config:
-rm /etc/lighttpd/conf-enabled/99-unconfigured.conf
+if [ -f /etc/lighttpd/conf-enabled/99-unconfigured.conf ]; then
+  rm /etc/lighttpd/conf-enabled/99-unconfigured.conf
+fi
 ## Remove the default lighttpd placeholder page for good measure
-rm /var/www/html/index.lighttpd.html
+if [ -f /var/www/html/index.lighttpd.html ]; then
+  rm /var/www/html/index.lighttpd.html
+fi
 ## Remove redundant directories created by the installer to reduce docker image size
 rm -rf /tmp/*
 

--- a/src/s6/debian-root/usr/local/bin/install.sh
+++ b/src/s6/debian-root/usr/local/bin/install.sh
@@ -13,14 +13,10 @@ detect_arch() {
   DETECTED_ARCH=$(arch)
   S6_ARCH=$DETECTED_ARCH
   case $DETECTED_ARCH in
-  amd64)
-    S6_ARCH="x86_64";;
   armel)
     S6_ARCH="armhf";;
-  armhf)
+  armv7l)
     S6_ARCH="armhf";;
-  arm64)
-    S6_ARCH="aarch64";;
   i386)
     S6_ARCH="i686";;
 esac


### PR DESCRIPTION
## Description
Tweaks three commands
- detect the architecture using `arch`. Not all distros use `dpkg`
- `killall` requires the `-s|--signal` flag for any signal execpt `SIGTERM`
- only delete files that exist

## Motivation and Context
Makes the image more portable. Mountain is coming.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

