### PR TITLE
Do not try to remove stale label on PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,8 +29,11 @@ jobs:
         operations-per-run: 300
         close-issue-reason: 'not_planned'
 
-  remove_stale: # trigger "stale" removal immediately when stale issues are commented on
-    if: github.event_name == 'issue_comment'
+  remove_stale:
+    # trigger "stale" removal immediately when stale issues are commented on
+    # we need to explicitly check that the trigger does not run on comment on a PR as
+    # 'issue_comment' triggers on issues AND PR comments
+    if: github.event_name == 'issue_comment' && ${{ !github.event.issue.pull_request }}
     permissions:
       contents: read #  for actions/checkout
       issues: write #  to edit issues label


### PR DESCRIPTION
## PR master branch!

**What does this PR aim to accomplish?:**

PR https://github.com/pi-hole/docker-pi-hole/pull/1344 added the workflow to remove the 'stale' label from issues immediately when a stale issue received new comments. However, the github event `issue_comment` also triggers on  **PR comments** (see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issue_comment).

As we don't  handle stale PR with this workflow PR write permission is not granted and the workflow will fail (see https://github.com/pi-hole/pi-hole/actions/runs/5109474838/jobs/9184306155)

This PR adds an additional check to verify the action is not triggered by  comments on pull requests. (see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issue_comment-on-issues-only-or-pull-requests-only) 

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
