### PR TITLE
Re-implement SKIPGRAVITYONBOOT

### DIFF
--- a/src/start.sh
+++ b/src/start.sh
@@ -77,7 +77,17 @@ sed -i "s/59 17/$((1 + RANDOM % 58)) $((12 + RANDOM % 8))/" /crontab.txt
 
 /usr/sbin/crond
 
-pihole -g
+gravityDBfile=$(getFTLConfigValue files.gravity)
+
+if [ -z "$SKIPGRAVITYONBOOT" ] || [ ! -f "${gravityDBfile}" ]; then
+    if [ -n "$SKIPGRAVITYONBOOT" ];then
+        echo "  SKIPGRAVITYONBOOT is set, however ${gravityDBfile} does not exist (Likely due to a fresh volume). This is a required file for Pi-hole to operate."
+        echo "  Ignoring SKIPGRAVITYONBOOT on this occaision."
+    fi
+    pihole -g
+else
+    echo "  Skipping Gravity Database Update."
+fi
 
 pihole updatechecker
 


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

v5 container allows user to skip gravity on container start by passing the environment variable `SKIPGRAVITYONBOOT` (with any value) - this was removed in the initial testing stage, so I am now adding it back in.

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_