### PR TITLE
Allow `pihole` user to run `pihole` command as the `pihole` user

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -38,6 +38,7 @@ RUN if   [ "$TARGETPLATFORM" = "linux/amd64" ];    then FTLARCH=amd64; \
 
 ADD https://ftl.pi-hole.net/macvendor.db /macvendor.db
 COPY crontab.txt /crontab.txt
+COPY pihole.sudo /etc/sudoers.d/pihole
 
 RUN cd /etc/.pihole && \
     install -Dm755 -d /opt/pihole && \

--- a/src/pihole.sudo
+++ b/src/pihole.sudo
@@ -1,0 +1,1 @@
+pihole ALL = NOPASSWD: /usr/local/bin/pihole"


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Fixes an issue where `pihole -g` could not be run from the web interface. Or, more accurately, the api could not run `pihole -g` as the user `pihole`

See also: https://github.com/pi-hole/pi-hole/pull/5341

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_