### PR TITLE
Allow branch names to be passed in as build args

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -19,9 +19,13 @@ RUN apk add --no-cache \
     coreutils \
     procps
 
+ARG WEB_BRANCH="development-v6"
+ARG CORE_BRANCH="development-v6"
+ARG FTL_BRANCH="development-v6"
+
 # download a the main repos from github
-RUN git clone --depth 1 --single-branch --branch development-v6 https://github.com/pi-hole/AdminLTE.git /var/www/html/admin && \
-    git clone --depth 1 --single-branch --branch development-v6 https://github.com/pi-hole/pi-hole.git /etc/.pihole
+RUN git clone --depth 1 --single-branch --branch ${WEB_BRANCH} https://github.com/pi-hole/AdminLTE.git /var/www/html/admin && \
+    git clone --depth 1 --single-branch --branch ${CORE_BRANCH} https://github.com/pi-hole/pi-hole.git /etc/.pihole
 
 # Download the latest version of pihole-FTL for alpine:
 # Probably need this to be built for different FTLARCHs
@@ -32,7 +36,7 @@ RUN if   [ "$TARGETPLATFORM" = "linux/amd64" ];    then FTLARCH=amd64; \
     elif [ "$TARGETPLATFORM" = "linux/arm64/v8" ]; then FTLARCH=armv64; \
     elif [ "$TARGETPLATFORM" = "linux/riscv64" ];  then FTLARCH=riscv64; \
     else FTLARCH=amd64; fi \
-    && curl -sSL "https://ftl.pi-hole.net/development-v6/pihole-FTL-${FTLARCH}" -o /usr/bin/pihole-FTL && \
+    && curl -sSL "https://ftl.pi-hole.net/${FTL_BRANCH}/pihole-FTL-${FTLARCH}" -o /usr/bin/pihole-FTL && \
     chmod +x /usr/bin/pihole-FTL
 
 


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

This makes it easier to build the image with different branches without changing the dockerfile, e.g:

```
docker build src/. --tag ph-development-v6 --no-cache --build-arg WEB_BRANCH=alt/branchname
```

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_