### PR TITLE
Make the FTL log tail optional. Pass in `TAIL_FTL_LOG: 0` to silence it

### DIFF
--- a/src/start.sh
+++ b/src/start.sh
@@ -127,7 +127,7 @@ start() {
   capsh --user=$DNSMASQ_USER --keep=1 -- -c "/usr/bin/pihole-FTL $FTL_CMD >/dev/null" &
 
   if [ "${TAIL_FTL_LOG:-1}" -eq 1 ]; then
-    tail -f /var/log/pihole-FTL.log &
+    tail -f /var/log/pihole/FTL.log &
   else
     echo "  [i] FTL log output is disabled. Remove the Environment variable TAIL_FTL_LOG, or set it to 1 to enable FTL log output."
   fi

--- a/src/start.sh
+++ b/src/start.sh
@@ -114,7 +114,7 @@ start() {
   fi
 
   if [ -n "${SKIPGRAVITYONBOOT}" ]; then
-    echo "  Skipping Gravity Database Update."
+    echo "  [i] Skipping Gravity Database Update."
   else
     pihole -g
   fi
@@ -126,7 +126,11 @@ start() {
   sh /opt/pihole/pihole-FTL-prestart.sh
   capsh --user=$DNSMASQ_USER --keep=1 -- -c "/usr/bin/pihole-FTL $FTL_CMD >/dev/null" &
 
-  tail -f /var/log/pihole-FTL.log &
+  if [ "${TAIL_FTL_LOG:-1}" -eq 1 ]; then
+    tail -f /var/log/pihole-FTL.log &
+  else
+    echo "  [i] FTL log output is disabled. Remove the Environment variable TAIL_FTL_LOG, or set it to 1 to enable FTL log output."
+  fi
 
   # https://stackoverflow.com/a/49511035
   wait $!


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

See title. By default the image will tail the FTL log. Users can disable this if it is too noisy for their preference

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_