### PR TITLE
Reduce git clone size, by cloning only what is needed

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -20,8 +20,8 @@ RUN apk add --no-cache \
     procps
 
 # download a the main repos from github
-RUN git clone --branch development-v6 https://github.com/pi-hole/AdminLTE.git /var/www/html/admin && \
-    git clone --branch development-v6 https://github.com/pi-hole/pi-hole.git /etc/.pihole
+RUN git clone --depth 1 --single-branch --branch development-v6 https://github.com/pi-hole/AdminLTE.git /var/www/html/admin && \
+    git clone --depth 1 --single-branch --branch development-v6 https://github.com/pi-hole/pi-hole.git /etc/.pihole
 
 # Download the latest version of pihole-FTL for alpine:
 # Probably need this to be built for different FTLARCHs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I've managed to reduce the general container size, but telling git not to clone the whole repo.

## Description
<!--- Describe your changes in detail -->
When doing a `git clone`, git while clone the whole repo (seem logical haha), but for the container we don't need all of the branch, old commits etc, etc...
So we only tell git clone, to clone what we need (the latest commit and only this branch that we tell it)
edit: For that we use `-depth 1` & `--single-branch` to do it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It reduce the size of the docker container significantly !
From 117MB (currently from the latest pull) to 73.3MB ! (-43.8MB less)
(i wanted to get the % of it but idk how haha)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Wasn't breaking anything on my side.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvment

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
