### PR TITLE
Add `ncurses` back in for the time being to fix pihole -v output.

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -17,7 +17,8 @@ RUN apk add --no-cache \
     iproute2-ss \
     jq \
     coreutils \
-    procps
+    procps \
+    ncurses
 
 # download a the main repos from github
 RUN git clone --depth 1 --single-branch --branch development-v6 https://github.com/pi-hole/AdminLTE.git /var/www/html/admin && \


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

It was removed in #1366, but see https://github.com/pi-hole/docker-pi-hole/issues/1359#issuecomment-1644385214  for details on why it needs to go back in for now


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_