### PR TITLE
Add tzdata package so that users can define their own timezone at runtime

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -27,7 +27,8 @@ RUN apk add --no-cache \
     coreutils \
     procps \
     ncurses \
-    binutils
+    binutils \
+    tzdata
 
 ADD https://ftl.pi-hole.net/macvendor.db /macvendor.db
 COPY crontab.txt /crontab.txt


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Assuming the time zone is set in the environment  with:
```yaml
environment:
     TZ: 'Europe/London'
```

Before:
```
pihole:/# date
Sun Jul 23 20:17:53 UTC 2023
```

After:
```
pihole:/# date
Sun Jul 23 21:17:29 BST 2023
```


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_