### PR TITLE
re-add the PIHOLE_DOCKER_TAG build arg that went missing along the way

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -20,6 +20,9 @@ RUN apk add --no-cache \
     procps \
     ncurses
 
+ARG PIHOLE_DOCKER_TAG="unknown"
+RUN echo "${PIHOLE_DOCKER_TAG}" > /pihole.docker.tag
+
 ARG WEB_BRANCH="development-v6"
 ARG CORE_BRANCH="development-v6"
 ARG FTL_BRANCH="development-v6"


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

While we still use `pihole -v` and `pihole updatechecker` (these may be removed from the container at a later date), reimplement the same behaviour as the v5 containers - in which the `PIHOLE_DOCKER_TAG` is baked into the image and stored at `/pihole.docker.tag` per:

https://github.com/pi-hole/docker-pi-hole/blob/958f40184dcd6f1c58c1da7d9887170db9273fb0/src/Dockerfile#L5

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_