### PR TITLE
add uid/gid modification to match hosts uid/gid

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -27,6 +27,7 @@ RUN apk add --no-cache \
     coreutils \
     procps \
     ncurses \
+    shadow \
     binutils \
     tzdata
 

--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -198,6 +198,30 @@ setup_web_password() {
     fi
 }
 
+modifyUser()
+{
+  declare username=${1:-} newId=${2:-}
+  [[ -z ${username} || -z ${newId} ]] && return
+
+  local currentId=$(id -u ${username})
+  [[ ${currentId} -eq ${newId} ]] && return
+
+  echo "  [i] Changing ID for user: ${username} (${currentId} => ${newId})"
+  usermod -o -u ${newId} ${username}
+}
+
+modifyGroup()
+{
+  declare groupname=${1:-} newId=${2:-}
+  [[ -z ${groupname} || -z ${newId} ]] && return
+
+  local currentId=$(id -g ${groupname})
+  [[ ${currentId} -eq ${newId} ]] && return
+
+  echo "  [i] Changing ID for group: ${groupname} (${currentId} => ${newId})"
+  groupmod -o -g ${newId} ${groupname}
+}
+
 # setup_blocklists() {
 #     # Exit/return early without setting up adlists with defaults for any of the following conditions:
 #     # 1. skip_setup_blocklists env is set

--- a/src/start.sh
+++ b/src/start.sh
@@ -9,6 +9,8 @@ fi
 # shellcheck source=/dev/null
 . /usr/bin/bash_functions.sh
 
+modifyUser pihole ${PIHOLE_UID}
+modifyGroup pihole ${PIHOLE_GID}
 
 # shellcheck source=/dev/null
 # SKIP_INSTALL=true . /etc/.pihole/automated\ install/basic-install.sh


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
When using mounted volumes, container uid/gid have to match hosts uid/gid in order to have rights on the files.

## Description
<!--- Describe your changes in detail -->
set pihole uid/gid according to env values PIHOLE_UID/PIHOLE_GID

this feature was already present in previous pihole versions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
docker-pi-hole-pihole-1  | 2023-07-26 08:07:12.945 [177M] WARNING: chmod(/etc/pihole/pihole-FTL.db, 436): chmod() failed: Operation not permitted
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
When setting uid/gid, no more warning are displayed in the container logs.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
