### PR TITLE
if skipgravityonboot set, check db version.

### DIFF
--- a/src/start.sh
+++ b/src/start.sh
@@ -110,6 +110,7 @@ if [ -n "${SKIPGRAVITYONBOOT}" ]; then
   if [ -f "${gravityDBfile}" ]; then
     #skip set + file =>update if needed
     echo "  Skipping Gravity Database Update."
+    # TODO: Revist this path if we move to a multistage build
     source /etc/.pihole/advanced/Scripts/database_migration/gravity-db.sh
     upgrade_gravityDB "${gravityDBfile}" "/etc/pihole"
   else


### PR DESCRIPTION

during pihole -g version is checked and db updated if needed.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
At boot time either run pihole -g or check and upgrade database structure if needed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Updating everyday or at every start lists may be of little use and harsh on lists servers.
Allowing to bypass update at boot time, speed up the start and avoid traffic on lists servers.
Some lists are on github servers, too many accesses may trigger ban rules.

Fix #1398 

When SKIPGRAVITYONBOOT is not set (default), pihole -g runs at boot time.
it checks database's version and upgrade it if needed.

SKIPGRAVITYONBOOT allows to bypass the "pihole -g" step, hence database version is not checked anymore, lists are not updated.
Depending on the last update, incorrect version will cause many errors in the admin website.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I copied v5 databases to v6 container's volumes, an checked that database structure was updated and lists were not.

```
docker-pi-hole-pihole-1  | + gravityDBfile=/etc/pihole/gravity.db
docker-pi-hole-pihole-1  | + '[' -n true ']'
docker-pi-hole-pihole-1  | + '[' -f /etc/pihole/gravity.db 
docker-pi-hole-pihole-1  | ']'
docker-pi-hole-pihole-1  |   Skipping Gravity Database Update.
docker-pi-hole-pihole-1  | + echo '  Skipping Gravity Database Update.'
docker-pi-hole-pihole-1  | + source /opt/pihole/utils.sh
docker-pi-hole-pihole-1  | + source /etc/.pihole/advanced/Scripts/database_migration/gravity-db.sh
docker-pi-hole-pihole-1  | ++ readonly scriptPath=/etc/.pihole/advanced/Scripts/database_migration/gravity
docker-pi-hole-pihole-1  | ++ scriptPath=/etc/.pihole/advanced/Scripts/database_migration/gravity
docker-pi-hole-pihole-1  | + upgrade_gravityDB /etc/pihole/gravity.db /etc/pihole
docker-pi-hole-pihole-1  | + local database 
docker-pi-hole-pihole-1  | piholeDir 
docker-pi-hole-pihole-1  | auditFile version
docker-pi-hole-pihole-1  | + database=/etc/pihole/gravity.db
docker-pi-hole-pihole-1  | + 
docker-pi-hole-pihole-1  | piholeDir=/etc/pihole
docker-pi-hole-pihole-1  | + auditFile=/etc/pihole/auditlog.list
docker-pi-hole-pihole-1  | ++ pihole-FTL sqlite3 /etc/pihole/gravity.db 'SELECT "value" FROM "info" WHERE "property" = '\''version'\'';'
docker-pi-hole-pihole-1  | + version=16
docker-pi-hole-pihole-1  | + [[ 16 == \1 ]]
docker-pi-hole-pihole-1  | + [[ 16
docker-pi-hole-pihole-1  |  == 
docker-pi-hole-pihole-1  | \2 ]]
docker-pi-hole-pihole-1  | + [[ 
docker-pi-hole-pihole-1  | 16 == \3 ]]
docker-pi-hole-pihole-1  | + [[ 16 == \4 ]]
docker-pi-hole-pihole-1  | + 
docker-pi-hole-pihole-1  | [[ 16
docker-pi-hole-pihole-1  |  == 
docker-pi-hole-pihole-1  | \5 ]]
docker-pi-hole-pihole-1  | + [[ 16 == \6 ]]
docker-pi-hole-pihole-1  | + [[ 16 == \7 ]]
docker-pi-hole-pihole-1  | + [[ 16 == \8 ]]
docker-pi-hole-pihole-1  | + [[ 16 == \9 ]]
docker-pi-hole-pihole-1  | + [[ 16 == \1\0 ]]
docker-pi-hole-pihole-1  | + [[ 16 == \1\1 ]]
docker-pi-hole-pihole-1  | + [[ 16 == \1\2 ]]
docker-pi-hole-pihole-1  | + [[ 16 == \1\3 ]]
docker-pi-hole-pihole-1  | + [[ 16 == \1\4 ]]
docker-pi-hole-pihole-1  | + [[ 16 == \1\5 ]]
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
