### PR TITLE
Ensure pihole-FTL process is shut down cleanly on container exit / add tini

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -28,6 +28,7 @@ RUN apk add --no-cache \
     psmisc \
     shadow \
     sudo \
+    tini \
     tzdata \
     unzip \
     wget
@@ -71,4 +72,4 @@ COPY --chmod=0755 start.sh /usr/bin/start.sh
 
 HEALTHCHECK CMD dig +short +norecurse +retry=0 @127.0.0.1 pi.hole || exit 1
 
-ENTRYPOINT [ "start.sh" ]
+ENTRYPOINT ["/bin/tini", "--", "start.sh"]

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -72,4 +72,4 @@ COPY --chmod=0755 start.sh /usr/bin/start.sh
 
 HEALTHCHECK CMD dig +short +norecurse +retry=0 @127.0.0.1 pi.hole || exit 1
 
-ENTRYPOINT ["/bin/tini", "--", "start.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "start.sh"]

--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -52,9 +52,12 @@ ensure_basic_configuration() {
     # chown pihole:root "${PI_HOLE_BIN_DIR}/pihole"
 
     mkdir -p /etc/pihole
-    if [[ ! -f /etc/pihole/adlists.list ]]; then
-        echo "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts" > /etc/pihole/adlists.list
+    if [[ -z "${PYTEST}" ]]; then
+        if [[ ! -f /etc/pihole/adlists.list ]]; then
+            echo "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts" >/etc/pihole/adlists.list
+        fi
     fi
+
     chown -R pihole:pihole /etc/pihole
 
 

--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -52,7 +52,9 @@ ensure_basic_configuration() {
     # chown pihole:root "${PI_HOLE_BIN_DIR}/pihole"
 
     mkdir -p /etc/pihole
-    echo "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts" >> /etc/pihole/adlists.list
+    if [[ ! -f /etc/pihole/adlists.list ]]; then
+        echo "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts" > /etc/pihole/adlists.list
+    fi
     chown -R pihole:pihole /etc/pihole
 
 

--- a/src/start.sh
+++ b/src/start.sh
@@ -1,139 +1,151 @@
 #!/bin/bash -e
 
-if [ "${PH_VERBOSE:-0}" -gt 0 ] ; then
-    set -x ;
+if [ "${PH_VERBOSE:-0}" -gt 0 ]; then
+  set -x
 fi
 
-# The below functions are all contained in bash_functions.sh
-# shellcheck source=/dev/null
-. /usr/bin/bash_functions.sh
+trap stop TERM INT QUIT HUP ERR
 
+start() {
 
-# shellcheck source=/dev/null
-# SKIP_INSTALL=true . /etc/.pihole/automated\ install/basic-install.sh
+  # The below functions are all contained in bash_functions.sh
+  # shellcheck source=/dev/null
+  . /usr/bin/bash_functions.sh
 
-echo "  [i] Starting docker specific checks & setup for docker pihole/pihole"
+  # shellcheck source=/dev/null
+  # SKIP_INSTALL=true . /etc/.pihole/automated\ install/basic-install.sh
 
-# TODO:
-#if [ ! -f /.piholeFirstBoot ] ; then
-#    echo "   [i] Not first container startup so not running docker's setup, re-create container to run setup again"
-#else
-#    regular_setup_functions
-#fi
+  echo "  [i] Starting docker specific checks & setup for docker pihole/pihole"
 
-# Initial checks
-# ===========================
+  # TODO:
+  #if [ ! -f /.piholeFirstBoot ] ; then
+  #    echo "   [i] Not first container startup so not running docker's setup, re-create container to run setup again"
+  #else
+  #    regular_setup_functions
+  #fi
 
-# If PIHOLE_UID is set, modify the pihole user's id to match
-if [ -n "${PIHOLE_UID}" ]; then
-  currentId=$(id -u pihole)
-  if [[ ${currentId} -ne ${PIHOLE_UID} ]]; then
-    echo "  [i] Changing ID for user: pihole (${currentId} => ${PIHOLE_UID})"
-    usermod -o -u ${PIHOLE_UID} pihole
-  else
-   echo "  [i] ID for user pihole is already ${PIHOLE_UID}, no need to change"
+  # Initial checks
+  # ===========================
+
+  # If PIHOLE_UID is set, modify the pihole user's id to match
+  if [ -n "${PIHOLE_UID}" ]; then
+    currentId=$(id -u pihole)
+    if [[ ${currentId} -ne ${PIHOLE_UID} ]]; then
+      echo "  [i] Changing ID for user: pihole (${currentId} => ${PIHOLE_UID})"
+      usermod -o -u ${PIHOLE_UID} pihole
+    else
+      echo "  [i] ID for user pihole is already ${PIHOLE_UID}, no need to change"
+    fi
   fi
-fi
 
-# If PIHOLE_GID is set, modify the pihole group's id to match
-if [ -n "${PIHOLE_GID}" ]; then
-  currentId=$(id -g pihole)
-  if [[ ${currentId} -ne ${PIHOLE_GID} ]]; then
-    echo "  [i] Changing ID for group: pihole (${currentId} => ${PIHOLE_GID})"
-    groupmod -o -g ${PIHOLE_GID} pihole
-  else
-   echo "  [i] ID for group pihole is already ${PIHOLE_GID}, no need to change"
+  # If PIHOLE_GID is set, modify the pihole group's id to match
+  if [ -n "${PIHOLE_GID}" ]; then
+    currentId=$(id -g pihole)
+    if [[ ${currentId} -ne ${PIHOLE_GID} ]]; then
+      echo "  [i] Changing ID for group: pihole (${currentId} => ${PIHOLE_GID})"
+      groupmod -o -g ${PIHOLE_GID} pihole
+    else
+      echo "  [i] ID for group pihole is already ${PIHOLE_GID}, no need to change"
+    fi
   fi
-fi
 
-fix_capabilities
-# validate_env || exit 1
-ensure_basic_configuration
+  fix_capabilities
+  # validate_env || exit 1
+  ensure_basic_configuration
 
+  apply_FTL_Configs_From_Env
 
-apply_FTL_Configs_From_Env
+  # Web interface setup
+  # ===========================
+  # load_web_password_secret
+  # setup_web_password
 
-# Web interface setup
-# ===========================
-# load_web_password_secret
-# setup_web_password
+  # Misc Setup
+  # ===========================
+  # setup_blocklists
 
-# Misc Setup
-# ===========================
-# setup_blocklists
+  # FTL setup
+  # ===========================
 
-# FTL setup
-# ===========================
+  # setup_FTL_User
+  # setup_FTL_query_logging
 
-# setup_FTL_User
-# setup_FTL_query_logging
+  [ -f /.piholeFirstBoot ] && rm /.piholeFirstBoot
 
-[ -f /.piholeFirstBoot ] && rm /.piholeFirstBoot
+  echo "  [i] Docker start setup complete"
+  echo ""
 
-echo "  [i] Docker start setup complete"
-echo ""
+  echo "  [i] pihole-FTL ($FTL_CMD) will be started as ${DNSMASQ_USER}"
+  echo ""
 
-
-echo "  [i] pihole-FTL ($FTL_CMD) will be started as ${DNSMASQ_USER}"
-echo ""
-
-
-if [ "${PH_VERBOSE:-0}" -gt 0 ] ; then
-    set -x ;
-fi
-
-# Install editors inside container if requested
-if [ "${INSTALL_DEV_TOOLS:-0}" -gt 0 ] ; then
+  # Install editors inside container if requested
+  if [ "${INSTALL_DEV_TOOLS:-0}" -gt 0 ]; then
     apk add --no-cache nano less
-fi
+  fi
 
-# Remove possible leftovers from previous pihole-FTL processes
-rm -f /dev/shm/FTL-* 2> /dev/null
-rm -f /run/pihole/FTL.sock
+  # Remove possible leftovers from previous pihole-FTL processes
+  rm -f /dev/shm/FTL-* 2>/dev/null
+  rm -f /run/pihole/FTL.sock
 
+  # Start crond for scheduled scripts (logrotate, pihole flush, gravity update etc)
+  # crond
 
+  # Randomize gravity update time
+  sed -i "s/59 1 /$((1 + RANDOM % 58)) $((3 + RANDOM % 2))/" /crontab.txt
+  # Randomize update checker time
+  sed -i "s/59 17/$((1 + RANDOM % 58)) $((12 + RANDOM % 8))/" /crontab.txt
+  /usr/bin/crontab /crontab.txt
 
-# Start crond for scheduled scripts (logrotate, pihole flush, gravity update etc)
-# crond
-
-# Randomize gravity update time
-sed -i "s/59 1 /$((1 + RANDOM % 58)) $((3 + RANDOM % 2))/" /crontab.txt
-# Randomize update checker time
-sed -i "s/59 17/$((1 + RANDOM % 58)) $((12 + RANDOM % 8))/" /crontab.txt
-/usr/bin/crontab /crontab.txt
-
-/usr/sbin/crond
+  /usr/sbin/crond
 
 #migrate Database if needed:
-gravityDBfile=$(getFTLConfigValue files.gravity)
-if [ -n "${SKIPGRAVITYONBOOT}" ]; then
-  if [ -f "${gravityDBfile}" ]; then
-    #skip set + file =>update if needed
-    echo "  Skipping Gravity Database Update."
-    # TODO: Revist this path if we move to a multistage build
-    source /etc/.pihole/advanced/Scripts/database_migration/gravity-db.sh
-    upgrade_gravityDB "${gravityDBfile}" "/etc/pihole"
-  else
-    #skip set + nofile => pihole -g (install error)
-    echo "  SKIPGRAVITYONBOOT is set, however ${gravityDBfile} does not exist (Likely due to a fresh volume). This is a required file for Pi-hole to operate."
-    echo "  Ignoring SKIPGRAVITYONBOOT on this occasion."
-    pihole -g
-  fi
-else
-  #skip not set + no file => error => create file
-  #skip not set + file => update db + lists
-  pihole -g
-fi
+  gravityDBfile=$(getFTLConfigValue files.gravity)
+  if [ -n "${SKIPGRAVITYONBOOT}" ]; then
+    if [ -f "${gravityDBfile}" ]; then
+      #skip set + file =>update if needed
+      echo "  Skipping Gravity Database Update."
+      # TODO: Revist this path if we move to a multistage build
+      source /etc/.pihole/advanced/Scripts/database_migration/gravity-db.sh
+      upgrade_gravityDB "${gravityDBfile}" "/etc/pihole"
+    else
+      #skip set + nofile => pihole -g (install error)
+      echo "  SKIPGRAVITYONBOOT is set, however ${gravityDBfile} does not exist (Likely due to a fresh volume). This is a required file for Pi-hole to operate."
+      echo "  Ignoring SKIPGRAVITYONBOOT on this occasion."
+      pihole -g
+    fi
+    else
+        echo "  Skipping Gravity Database Update."
+    fi
 
-pihole updatechecker
+  pihole updatechecker
 
-# Start FTL. TODO: We need to either mock the service file or update the pihole script in the main repo to restart FTL if no init system is present
-sh /opt/pihole/pihole-FTL-prestart.sh
-capsh --user=$DNSMASQ_USER --keep=1 -- -c "/usr/bin/pihole-FTL $FTL_CMD >/dev/null" &
+  # Start pihole-FTL
 
-tail -f /var/log/pihole-FTL.log
+  sh /opt/pihole/pihole-FTL-prestart.sh
+  capsh --user=$DNSMASQ_USER --keep=1 -- -c "/usr/bin/pihole-FTL $FTL_CMD >/dev/null" &
 
-# Notes on above:
-# - DNSMASQ_USER default of pihole is in Dockerfile & can be overwritten by runtime container env
-# - /var/log/pihole/pihole*.log has FTL's output that no-daemon would normally print in FG too
-#   prevent duplicating it in docker logs by sending to dev null
+  tail -f /var/log/pihole-FTL.log &
+
+  # https://stackoverflow.com/a/49511035
+  wait $!
+  # Notes on above:
+  # - DNSMASQ_USER default of pihole is in Dockerfile & can be overwritten by runtime container env
+  # - /var/log/pihole/pihole*.log has FTL's output that no-daemon would normally print in FG too
+  #   prevent duplicating it in docker logs by sending to dev null
+
+}
+
+stop() {
+  # Ensure pihole-FTL shuts down cleanly on SIGTERM/SIGINT
+  ftl_pid=$(pgrep pihole-FTL)
+  killall --signal 15 pihole-FTL
+
+  # Wait for pihole-FTL to exit
+  while test -d /proc/"${ftl_pid}"; do
+    sleep 0.5
+  done
+
+  exit
+}
+
+start

--- a/src/start.sh
+++ b/src/start.sh
@@ -98,24 +98,26 @@ start() {
 
   /usr/sbin/crond
 
-#migrate Database if needed:
+  #migrate Database if needed:
   gravityDBfile=$(getFTLConfigValue files.gravity)
-  if [ -n "${SKIPGRAVITYONBOOT}" ]; then
-    if [ -f "${gravityDBfile}" ]; then
-      #skip set + file =>update if needed
-      echo "  Skipping Gravity Database Update."
-      # TODO: Revisit this path if we move to a multistage build
-      source /etc/.pihole/advanced/Scripts/database_migration/gravity-db.sh
-      upgrade_gravityDB "${gravityDBfile}" "/etc/pihole"
-    else
-      #skip set + nofile => pihole -g (install error)
+
+  if [ ! -f "${gravityDBfile}" ]; then
+    if [ -n "${SKIPGRAVITYONBOOT}" ]; then
       echo "  SKIPGRAVITYONBOOT is set, however ${gravityDBfile} does not exist (Likely due to a fresh volume). This is a required file for Pi-hole to operate."
       echo "  Ignoring SKIPGRAVITYONBOOT on this occasion."
-      pihole -g
+      unset SKIPGRAVITYONBOOT
     fi
-    else
-        echo "  Skipping Gravity Database Update."
-    fi
+  else
+    # TODO: Revisit this path if we move to a multistage build
+    source /etc/.pihole/advanced/Scripts/database_migration/gravity-db.sh
+    upgrade_gravityDB "${gravityDBfile}" "/etc/pihole"
+  fi
+
+  if [ -n "${SKIPGRAVITYONBOOT}" ]; then
+    echo "  Skipping Gravity Database Update."
+  else
+    pihole -g
+  fi
 
   pihole updatechecker
 

--- a/src/start.sh
+++ b/src/start.sh
@@ -104,7 +104,7 @@ start() {
     if [ -f "${gravityDBfile}" ]; then
       #skip set + file =>update if needed
       echo "  Skipping Gravity Database Update."
-      # TODO: Revist this path if we move to a multistage build
+      # TODO: Revisit this path if we move to a multistage build
       source /etc/.pihole/advanced/Scripts/database_migration/gravity-db.sh
       upgrade_gravityDB "${gravityDBfile}" "/etc/pihole"
     else

--- a/src/start.sh
+++ b/src/start.sh
@@ -147,6 +147,12 @@ stop() {
     sleep 0.5
   done
 
+  # If we are running pytest, keep the container alive for a little longer
+  # to allow the tests to complete
+  if [[ ${PYTEST} ]]; then
+    sleep 10
+  fi
+
   exit
 }
 

--- a/test/tests/conftest.py
+++ b/test/tests/conftest.py
@@ -36,18 +36,13 @@ def run_and_stream_command_output():
 
 
 @pytest.fixture()
-def args_volumes():
-    return "-v /dev/null:/etc/pihole/adlists.list"
-
-
-@pytest.fixture()
 def args_env():
     return '-e TZ="Europe/London"'
 
 
 @pytest.fixture()
-def args(args_volumes, args_env):
-    return "{} {}".format(args_volumes, args_env)
+def args(args_env):
+    return "{}".format(args_env)
 
 
 @pytest.fixture()

--- a/test/tests/test_general.py
+++ b/test/tests/test_general.py
@@ -1,11 +1,13 @@
 import pytest
 
+
 @pytest.mark.parametrize("test_args", ['-e "PIHOLE_UID=456"'])
 def test_pihole_uid_env_var(docker):
-    func = docker.run('id -u pihole')
+    func = docker.run("id -u pihole")
     assert "456" in func.stdout
+
 
 @pytest.mark.parametrize("test_args", ['-e "PIHOLE_GID=456"'])
 def test_pihole_gid_env_var(docker):
-    func = docker.run('id -g pihole')
+    func = docker.run("id -g pihole")
     assert "456" in func.stdout

--- a/test/tests/test_general.py
+++ b/test/tests/test_general.py
@@ -11,3 +11,20 @@ def test_pihole_uid_env_var(docker):
 def test_pihole_gid_env_var(docker):
     func = docker.run("id -g pihole")
     assert "456" in func.stdout
+
+
+# We immediately remove the adlists.list file so that gravity does not attempt to download a default list
+# Wait 5 seconds for gravity to finish, then kill the start.sh script
+# Finally, tail the FTL log to see if it shuts down cleanly
+@pytest.mark.parametrize("test_args", ['-e "PH_VERBOSE=1"'])
+def test_pihole_ftl_clean_shutdown(docker):
+    func = docker.run(
+        """
+        sleep 5
+        killall --signal 15 start.sh
+        sleep 5
+        tail -f /var/log/pihole-FTL.log
+    """
+    )
+    assert "INFO: Shutting down... // exit code 0 // jmpret 0" in func.stdout
+    assert "INFO: ########## FTL terminated after" in func.stdout


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

While playing around with adding `tini` into the container, I realised that it wasn't a lot of good because `start.sh` will always be the sole child process of  `tini` - and it can only have one child.

As pihole-FTL is spawned as a child of `start.sh`, we would need to add in a trap to `start.sh` anyway, to forward that onto `pihole-FTL`

~~Seems like we can just skip adding `tini` (saving a whopping 2MB in the process 😏) and just trap for exits and shut down `pihole-FTL` first.~~

Revision: Include tini for it's zombie process reaping abilities. If it turns out to be more than needed, we can remove it in a future step


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_