### PR TITLE
Tell alpine specifically to install/use procps-ng

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -25,7 +25,7 @@ RUN apk add --no-cache \
     iproute2-ss \
     jq \
     coreutils \
-    procps \
+    procps-ng \
     ncurses \
     binutils \
     tzdata \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Tell Alpine to specifically install/use `procps-ng` instead of `procps` 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In Alpine `procps` alone doesn't exist there is only `procps-ng` & `procps-compat` (which is the old version of procps).
Telling Alpine just `procps` alone doesn't seem to be an issue to be honest and it will use `procps-ng` automatically, but i guess just for the peace of mind just directly tell it.

</br>
For context about procps-ng:
Procps-ng is a fork of the original procps (which is unmaintained now), and is maintained now by the maintainers
of Debian, Fedora and openSUSE.

https://gitlab.com/procps-ng/procps/-/wikis/home 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
It didn't change anything since Alpine already used it alredy.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
