### PR TITLE
Add PADD to the image

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -35,8 +35,7 @@ ADD https://ftl.pi-hole.net/macvendor.db /macvendor.db
 COPY crontab.txt /crontab.txt
 
 # Add PADD to the container, too.
-ADD https://raw.githubusercontent.com/pi-hole/PADD/PADD_FTLv6/padd.sh /usr/local/bin/padd
-RUN chmod +x /usr/local/bin/padd
+ADD --chmod=0755 https://raw.githubusercontent.com/pi-hole/PADD/PADD_FTLv6/padd.sh /usr/local/bin/padd
 
 # download a the main repos from github
 RUN git clone --depth 1 --single-branch --branch ${WEB_BRANCH} https://github.com/pi-hole/AdminLTE.git /var/www/html/admin && \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -7,6 +7,7 @@ ARG WEB_BRANCH="development-v6"
 ARG CORE_BRANCH="development-v6"
 ARG FTL_BRANCH="development-v6"
 ARG PIHOLE_DOCKER_TAG="unknown"
+ARG PADD_BRANCH="PADD_FTLv6"
 
 ENV DNSMASQ_USER=pihole
 ENV FTL_CMD=no-daemon
@@ -35,7 +36,7 @@ ADD https://ftl.pi-hole.net/macvendor.db /macvendor.db
 COPY crontab.txt /crontab.txt
 
 # Add PADD to the container, too.
-ADD --chmod=0755 https://raw.githubusercontent.com/pi-hole/PADD/PADD_FTLv6/padd.sh /usr/local/bin/padd
+ADD --chmod=0755 https://raw.githubusercontent.com/pi-hole/PADD/${PADD_BRANCH}/padd.sh /usr/local/bin/padd
 
 # download a the main repos from github
 RUN git clone --depth 1 --single-branch --branch ${WEB_BRANCH} https://github.com/pi-hole/AdminLTE.git /var/www/html/admin && \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -34,6 +34,10 @@ RUN apk add --no-cache \
 ADD https://ftl.pi-hole.net/macvendor.db /macvendor.db
 COPY crontab.txt /crontab.txt
 
+# Add PADD to the container, too.
+ADD https://raw.githubusercontent.com/pi-hole/PADD/PADD_FTLv6/padd.sh /usr/local/bin/padd
+RUN chmod +x /usr/local/bin/padd
+
 # download a the main repos from github
 RUN git clone --depth 1 --single-branch --branch ${WEB_BRANCH} https://github.com/pi-hole/AdminLTE.git /var/www/html/admin && \
     git clone --depth 1 --single-branch --branch ${CORE_BRANCH} https://github.com/pi-hole/pi-hole.git /etc/.pihole ;\

--- a/src/start.sh
+++ b/src/start.sh
@@ -87,9 +87,6 @@ if [ "${INSTALL_DEV_TOOLS:-0}" -gt 0 ] ; then
     apk add --no-cache nano less
 fi
 
-# Add an alias for padd to the root user's bashrc
-port="${FTLCONF_webserver_port%%,*}"
-echo "alias padd='padd --port ${port:-8080} --secret ${FTLCONF_webserver_api_password}'" > /root/.bashrc
 
 # Remove possible leftovers from previous pihole-FTL processes
 rm -f /dev/shm/FTL-* 2> /dev/null

--- a/src/start.sh
+++ b/src/start.sh
@@ -87,6 +87,10 @@ if [ "${INSTALL_DEV_TOOLS:-0}" -gt 0 ] ; then
     apk add --no-cache nano less
 fi
 
+# Add an alias for padd to the root user's bashrc
+port="${FTLCONF_webserver_port%%,*}"
+echo "alias padd='padd --port ${port:-8080} --secret ${FTLCONF_webserver_api_password}'" > /root/.bashrc
+
 # Remove possible leftovers from previous pihole-FTL processes
 rm -f /dev/shm/FTL-* 2> /dev/null
 rm -f /run/pihole/FTL.sock

--- a/src/start.sh
+++ b/src/start.sh
@@ -87,7 +87,6 @@ if [ "${INSTALL_DEV_TOOLS:-0}" -gt 0 ] ; then
     apk add --no-cache nano less
 fi
 
-
 # Remove possible leftovers from previous pihole-FTL processes
 rm -f /dev/shm/FTL-* 2> /dev/null
 rm -f /run/pihole/FTL.sock


### PR DESCRIPTION
Add the v6 development version of PADD to the image. 

PADD expects the API at port 80, currently FTL still defaults to 8080. Therefore, PADD needs to be started with `padd --port 8080`

![Screenshot at 2023-07-31 23-33-02](https://github.com/pi-hole/docker-pi-hole/assets/26622301/a8f0ded0-97bf-4ce7-99b8-9759b96e37d3)
