### PR TITLE
Fix permission denied when writing configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ services:
       # WEBPASSWORD: 'set a secure password here or it will be random'
     # Volumes store your data between container upgrades
     volumes:
-      - './etc-pihole:/etc/pihole'
-      - './etc-dnsmasq.d:/etc/dnsmasq.d'
+      - './etc-pihole:/etc/pihole:z' # Adding `:z` for Red Hat base distribution with an SELinux enforcing policy
+      - './etc-dnsmasq.d:/etc/dnsmasq.d:z'
     #   https://github.com/pi-hole/docker-pi-hole#note-on-capabilities
     cap_add:
       - NET_ADMIN # Required if you are using Pi-hole as your DHCP server, else not needed

--- a/examples/docker-compose.yml.example
+++ b/examples/docker-compose.yml.example
@@ -17,9 +17,9 @@ services:
       # WEBPASSWORD: 'set a secure password here or it will be random'
     # Volumes store your data between container upgrades
     volumes:
-      - './etc-pihole:/etc/pihole'
-      - './etc-dnsmasq.d:/etc/dnsmasq.d'
+      - './etc-pihole:/etc/pihole:z' # Adding `:z` for Red Hat base distribution with an SELinux enforcing policy
+      - './etc-dnsmasq.d:/etc/dnsmasq.d:z'
     #   https://github.com/pi-hole/docker-pi-hole#note-on-capabilities
     cap_add:
-      - NET_ADMIN
-    restart: unless-stopped # Recommended but not required (DHCP needs NET_ADMIN)  
+      - NET_ADMIN # Required if you are using Pi-hole as your DHCP server, else not needed
+    restart: unless-stopped


### PR DESCRIPTION
## Description

Added `:z` to avoid permission denied error on Red Hat base distribution with an SELinux enforcing policy


## Motivation and Context

Fix: #1432 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested on Fedora 28 Silverblue.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
