### PR TITLE
Disable dhcp if DHCP_ACTIVE is set to false

### DIFF
--- a/src/s6/debian-root/usr/local/bin/_startup.sh
+++ b/src/s6/debian-root/usr/local/bin/_startup.sh
@@ -49,7 +49,7 @@ setup_blocklists
 # FTL setup
 # ===========================
 setup_FTL_upstream_DNS
-[[ -n "${DHCP_ACTIVE}" && ${DHCP_ACTIVE} == "true" ]] && echo "Setting DHCP server" && setup_FTL_dhcp
+setup_FTL_dhcp
 apply_FTL_Configs_From_Env
 setup_FTL_User
 setup_FTL_Interface

--- a/src/s6/debian-root/usr/local/bin/bash_functions.sh
+++ b/src/s6/debian-root/usr/local/bin/bash_functions.sh
@@ -212,18 +212,24 @@ apply_FTL_Configs_From_Env(){
 }
 
 setup_FTL_dhcp() {
-  if [ -z "${DHCP_START}" ] || [ -z "${DHCP_END}" ] || [ -z "${DHCP_ROUTER}" ]; then
-    echo "  [!] ERROR: Won't enable DHCP server because mandatory Environment variables are missing: DHCP_START, DHCP_END and/or DHCP_ROUTER"
-    change_setting "DHCP_ACTIVE" "false"
+  if [[ -n "${DHCP_ACTIVE}" && ${DHCP_ACTIVE} == "true" ]]; then
+    if [ -z "${DHCP_START}" ] || [ -z "${DHCP_END}" ] || [ -z "${DHCP_ROUTER}" ]; then
+        echo "  [!] ERROR: Won't enable DHCP server because mandatory Environment variables are missing: DHCP_START, DHCP_END and/or DHCP_ROUTER"
+        change_setting "DHCP_ACTIVE" "false"
+    else
+        echo "  [i] Enabling DHCP server"
+        change_setting "DHCP_ACTIVE" "${DHCP_ACTIVE}"
+        change_setting "DHCP_START" "${DHCP_START}"
+        change_setting "DHCP_END" "${DHCP_END}"
+        change_setting "DHCP_ROUTER" "${DHCP_ROUTER}"
+        change_setting "DHCP_LEASETIME" "${DHCP_LEASETIME}"
+        change_setting "PIHOLE_DOMAIN" "${PIHOLE_DOMAIN}"
+        change_setting "DHCP_IPv6" "${DHCP_IPv6}"
+        change_setting "DHCP_rapid_commit" "${DHCP_rapid_commit}"
+    fi
   else
-    change_setting "DHCP_ACTIVE" "${DHCP_ACTIVE}"
-    change_setting "DHCP_START" "${DHCP_START}"
-    change_setting "DHCP_END" "${DHCP_END}"
-    change_setting "DHCP_ROUTER" "${DHCP_ROUTER}"
-    change_setting "DHCP_LEASETIME" "${DHCP_LEASETIME}"
-    change_setting "PIHOLE_DOMAIN" "${PIHOLE_DOMAIN}"
-    change_setting "DHCP_IPv6" "${DHCP_IPv6}"
-    change_setting "DHCP_rapid_commit" "${DHCP_rapid_commit}"
+    echo "  [i] Disabling DHCP server"
+    change_setting "DHCP_ACTIVE" "false"
   fi
 }
 

--- a/test/tests/test_bash_functions.py
+++ b/test/tests/test_bash_functions.py
@@ -288,3 +288,20 @@ def test_setup_lighttpd_bind(
         assert "server.bind" not in config.stdout
     else:
         assert f'server.bind		 = "{expected_bind}"' in config.stdout
+
+@pytest.mark.parametrize(
+    "test_args,expected_stdout",
+    [
+        ('-e "DHCP_ACTIVE=true"', "ERROR: Won't enable DHCP"),
+        ('-e "DHCP_ACTIVE=false"', "Disabling DHCP server"),
+        (
+            '-e "DHCP_ACTIVE=true" -e "DHCP_START=192.168.1.2" -e "DHCP_END=192.168.1.99" -e "DHCP_ROUTER=192.168.1.1"',
+            "Enabling DHCP server",
+        ),
+    ],
+)
+def test_env_dhcp(docker, args_env, test_args, expected_stdout):
+    """Ensure behaviour of DHCP_ACTIVE is correct"""
+    function = docker.run(". bash_functions.sh ; setup_FTL_dhcp")
+
+    assert expected_stdout in function.stdout


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

In the current version of Pi-hole docker image, you can enable the DHCP using the following environment variables:
- `DHCP_ACTIVE`
- `DHCP_START`
- `DHCP_END`
- `DHCP_ROUTER`

It works fine.
However, if you have a volume that persists your Pi-hole/Dnsmasq data, and you decide to restart the container with `DHCP_ACTIVE=false` the Pi-hole DHCP will stay enable.

So, I updated the code of `setup_FTL_dhcp` to correctly disable the DHCP if `DHCP_ACTIVE=false`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I have a personal project where the user defines the Pi-hole DHCP configuration before running the container.
Hence he/she could enable it, and then disable it.

I found a workaround which consists on setting `DHCP_ACTIVE=true`, but not defining the other mandatory environment variables.
The workaround is a bit counter-intuitive, so I thought it could be nice to have a proper behaviour.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I did one manual test on my personal project.
Moreover, I added unit tests to ensure the correct behaviour.
I do not really know Python, so I write the tests by mimicking the existing ones.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

I would define it as `Bug fix`. However, it changes a behaviour so maybe someone relies on this behaviour?

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

I did not find any code style. If something is wrong let me know.
I think the current documentation still is fine.