### PR TITLE
Add a wrapper/mock for the `service` command

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -69,6 +69,7 @@ RUN cd /etc/.pihole && \
 
 COPY --chmod=0755 bash_functions.sh /usr/bin/bash_functions.sh
 COPY --chmod=0755 start.sh /usr/bin/start.sh
+COPY --chmod=0755 service /usr/local/bin/service
 
 HEALTHCHECK CMD dig +short +norecurse +retry=0 @127.0.0.1 pi.hole || exit 1
 

--- a/src/service
+++ b/src/service
@@ -1,0 +1,109 @@
+#!/usr/bin/env sh
+# This script patches all service commands into the appropriate s6- commands
+# pi-hole upstream scripts need a 'service' interface. why not systemd? docker said so.
+
+# Source utils.sh for getFTLPIDFile(), getFTLPID()
+PI_HOLE_SCRIPT_DIR="/opt/pihole"
+utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
+# shellcheck disable=SC1090
+. "${utilsfile}"
+
+is_running() {
+  if [ -d "/proc/${FTL_PID}" ]; then
+    return 0
+  fi
+  return 1
+}
+
+cleanup() {
+    # Run post-stop script, which does cleanup among runtime files
+    sh "${PI_HOLE_SCRIPT_DIR}/pihole-FTL-poststop.sh"
+}
+
+# Start the service
+start() {
+  if is_running; then
+    echo "pihole-FTL is already running"
+  else
+    # Run pre-start script, which pre-creates all expected files with correct permissions
+    sh "${PI_HOLE_SCRIPT_DIR}/pihole-FTL-prestart.sh"
+    capsh --user=$DNSMASQ_USER --keep=1 -- -c "/usr/bin/pihole-FTL $FTL_CMD >/dev/null" &
+
+    rc=$?
+    # Cleanup if startup failed
+    if [ "${rc}" != 0 ]; then
+        cleanup
+        exit $rc
+    fi
+    echo
+  fi
+}
+
+# Stop the service
+stop() {
+  if is_running; then
+    kill "${FTL_PID}"
+    for i in 1 2 3 4 5; do
+      if ! is_running; then
+        break
+      fi
+
+      printf "."
+      sleep 1
+    done
+    echo
+
+    if is_running; then
+      echo "Not stopped; may still be shutting down or shutdown may have failed, killing now"
+      kill -9 "${FTL_PID}"
+    else
+      echo "Stopped"
+    fi
+  else
+    echo "Not running"
+  fi
+  cleanup
+  echo
+}
+
+# Indicate the service status
+status() {
+  if is_running; then
+    echo "[ ok ] pihole-FTL is running"
+    exit 0
+  else
+    echo "[    ] pihole-FTL is not running"
+    exit 1
+  fi
+}
+
+# Get FTL's PID file path
+FTL_PID_FILE="$(getFTLPIDFile)"
+
+# Get FTL's current PID
+FTL_PID="$(getFTLPID "${FTL_PID_FILE}")"
+
+if [ "$1" != "pihole-FTL" ]; then
+  # do something
+  echo "Service Wrapper only used for pihole-FTL in this docker container"
+  exit 1
+fi
+
+
+case "$2" in
+  stop)
+        stop
+        ;;
+  status)
+        status
+        ;;
+  start|restart|reload|condrestart)
+        stop
+        start
+        ;;
+  *)
+        echo "Usage: $0 {start|stop|restart|reload|status}"
+        exit 1
+esac
+
+exit 0

--- a/src/start.sh
+++ b/src/start.sh
@@ -131,10 +131,8 @@ start() {
 
   pihole updatechecker
 
-  # Start pihole-FTL
-
-  sh /opt/pihole/pihole-FTL-prestart.sh
-  capsh --user=$DNSMASQ_USER --keep=1 -- -c "/usr/bin/pihole-FTL $FTL_CMD >/dev/null" &
+  # Start pihole-FTL using the service-wrapper at /usr/local/bin/service
+  service pihole-FTL start
 
   if [ "${TAIL_FTL_LOG:-1}" -eq 1 ]; then
     tail -f /var/log/pihole/FTL.log &
@@ -152,14 +150,8 @@ start() {
 }
 
 stop() {
-  # Ensure pihole-FTL shuts down cleanly on SIGTERM/SIGINT
-  ftl_pid=$(pgrep pihole-FTL)
-  killall --signal 15 pihole-FTL
-
-  # Wait for pihole-FTL to exit
-  while test -d /proc/"${ftl_pid}"; do
-    sleep 0.5
-  done
+  # Stop pihole-FTL using the service-wrapper at /usr/local/bin/service
+  service pihole-FTL stop
 
   # If we are running pytest, keep the container alive for a little longer
   # to allow the tests to complete


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Allows for commands such as `pihole restartdns` to work without needing to modify core scripts.

Mostly "borrows" from the [service template](https://github.com/pi-hole/pi-hole/blob/master/advanced/Templates/pihole-FTL.service) for pihole-FTL, with a couple of tweaks thrown in.

If it is desired, I can probably also come up with/add some tests.

Addresses: https://discourse.pi-hole.net/t/restartdns-not-found/65540/7

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_