### PR TITLE
Add special handling for FTL Config names that have underscores in them

### DIFF
--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -127,11 +127,33 @@ apply_FTL_Configs_From_Env(){
         # Replace underscores with dots in the name to match pihole-FTL expectiations
         name="${name//_/.}"
 
-        # Special handing for the value if the name is dns.upstreams
-        if [ "$name" == "dns.upstreams" ]; then
-            value='["'${value//;/\",\"}'"]'
-        fi
 
+        # Special handling for some FTL Config values
+        case "$name" in
+            # Convert the semicolon separated list to a JSON array
+            "dns.upstreams")
+                value='["'${value//;/\",\"}'"]'
+                ;;
+            # The following config names have an underscore in them,
+            # so we need to re-convert the dot back to an underscore
+            "webserver.tls.rev.proxy")
+                name="webserver.tls.rev_proxy"
+                ;;
+            "webserver.api.totp.secret")
+                name="webserver.api.totp_secret"
+                ;;
+            "webserver.api.allow.destructive")
+                name="webserver.api.allow_destructive"
+                ;;
+            "misc.delay.startup")
+                name="misc.delay_startup"
+                ;;
+            "misc.dnsmasq.lines")
+                name="misc.dnsmasq_lines"
+                ;;
+        esac
+
+        # Mask the value if it is a password, else display the value as is
         if [ "$name" == "webserver.api.password" ]; then
             masked_value=$(printf "%${#value}s" | tr " " "*")
         else


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Inspired by this topic on Discourse:

https://discourse.pi-hole.net/t/rev-proxy-cannot-be-set-from-env-vars/65618/1

There are a few FTL config names that have underscores in them, which are incorrectly replaced with `.`s when we read in the environment variables (which need to be passed in with `_` instead of `.` in order for the container OS to parse them

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_