### PR TITLE
!!!BREAKING CHANGE!!! use `printenv` instead of `declare` when converting `FTLCONF_` environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ services:
     restart: unless-stopped
 ```
 2. Run `docker compose up -d` to build and start pi-hole (Syntax may be `docker-compose` on older systems)
-3. If using Docker's default `bridge` network setting, set the environment variable `FTLCONF_dns_listeningMode` to `all`
+3. If using Docker's default `bridge` network setting, set the environment variable `FTLCONF_dns.listeningMode` to `all`
 
 [Here is an equivalent docker run script](https://github.com/pi-hole/docker-pi-hole/blob/master/examples/docker_run.sh).
 
@@ -90,8 +90,8 @@ There are other environment variables if you want to customize various things in
 | Variable | Default | Value | Description |
 | -------- | ------- | ----- | ---------- |
 | `TZ` | UTC | `<Timezone>` | Set your [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) to make sure logs rotate at local midnight instead of at UTC midnight.
-| `FTLCONF_webserver_api_password` | random | `<Admin password>` | http://pi.hole/admin password. Run `docker logs pihole \| grep random` to find your random pass.
-| `FTLCONF_dns_upstreams` |  `8.8.8.8;8.8.4.4` | IPs delimited by `;` | Upstream DNS server(s) for Pi-hole to forward queries to, separated by a semicolon <br/> (supports non-standard ports with `#[port number]`) e.g `127.0.0.1#5053;8.8.8.8;8.8.4.4` <br/> (supports [Docker service names and links](https://docs.docker.com/compose/networking/) instead of IPs) e.g `upstream0;upstream1` where `upstream0` and `upstream1` are the service names of or links to docker services <br/> Note: The existence of this environment variable assumes this as the _sole_ management of upstream DNS. Upstream DNS added via the web interface will be overwritten on container restart/recreation |
+| `FTLCONF_webserver.api.password` | random | `<Admin password>` | http://pi.hole/admin password. Run `docker logs pihole \| grep random` to find your random pass.
+| `FTLCONF_dns.upstreams` |  `8.8.8.8;8.8.4.4` | IPs delimited by `;` | Upstream DNS server(s) for Pi-hole to forward queries to, separated by a semicolon <br/> (supports non-standard ports with `#[port number]`) e.g `127.0.0.1#5053;8.8.8.8;8.8.4.4` <br/> (supports [Docker service names and links](https://docs.docker.com/compose/networking/) instead of IPs) e.g `upstream0;upstream1` where `upstream0` and `upstream1` are the service names of or links to docker services <br/> Note: The existence of this environment variable assumes this as the _sole_ management of upstream DNS. Upstream DNS added via the web interface will be overwritten on container restart/recreation |
 
 ### Optional Variables
 
@@ -104,7 +104,7 @@ There are other environment variables if you want to customize various things in
 | -------- | ------- | ----- | ---------- |
 | `SKIPGRAVITYONBOOT` | unset | `<unset\|1>` | Use this option to skip updating the Gravity Database when booting up the container.  By default this environment variable is not set so the Gravity Database will be updated when the container starts up.  Setting this environment variable to 1 (or anything) will cause the Gravity Database to not be updated when container starts up.
 | `FTL_CMD` | `no-daemon` | `no-daemon -- <dnsmasq option>` | Customize the options with which dnsmasq gets started. e.g. `no-daemon -- --dns-forward-max 300` to increase max. number of concurrent dns queries on high load setups. |
-| `FTLCONF_[SETTING]` | unset | As per documentation | Customize pihole-FTL.conf with settings described in the <!!!Add Link To New API docs here before release!!!>. Replace `.` with `_`, e.g for `dns.dnssec=true` use `FTLCONF_dns_dnssec: 'true'`
+| `FTLCONF_[SETTING]` | unset | As per documentation | Customize pihole.toml with settings described in the <!!!Add Link To New API docs here before release!!!>. e.g for `dns.dnssec=true` use `FTLCONF_dns.dnssec: 'true'`
 | `PIHOLE_UID` | `999` | Number | Overrides image's default pihole user id to match a host user id<br/>**IMPORTANT**: id must not already be in use inside the container! |
 | `PIHOLE_GID` | `999` | Number | Overrides image's default pihole group id to match a host group id<br/>**IMPORTANT**: id must not already be in use inside the container!|
 | `DNSMASQ_USER` | unset | `<pihole\|root>` | Allows changing the user that FTLDNS runs as. Default: `pihole`, some systems such as Synology NAS may require you to change this to `root` (See [#963](https://github.com/pi-hole/docker-pi-hole/issues/963)) |

--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -122,11 +122,10 @@ apply_FTL_Configs_From_Env(){
     echo ""
     echo "==========Applying settings from environment variables=========="
     source /opt/pihole/COL_TABLE
-    declare -px | grep FTLCONF_ | sed -E 's/declare -x FTLCONF_([^=]+)=\"(|.+)\"/\1 \2/' | while read -r name value
-    do
-        # Replace underscores with dots in the name to match pihole-FTL expectiations
-        name="${name//_/.}"
 
+    # Loop through all environment variables that start with "FTLCONF_"
+    printenv | grep "^FTLCONF_" | sed -n 's/^FTLCONF_\([^=]*\)=\(.*\)/\1 \2/p' | while read -r name value
+    do
         # Special handing for the value if the name is dns.upstreams
         if [ "$name" == "dns.upstreams" ]; then
             value='["'${value//;/\",\"}'"]'

--- a/test/tests/test_bash_functions.py
+++ b/test/tests/test_bash_functions.py
@@ -5,14 +5,14 @@ import re
 CMD_APPLY_FTL_CONFIG_FROM_ENV = ". bash_functions.sh ; apply_FTL_Configs_From_Env"
 
 
-@pytest.mark.parametrize("test_args", ['-e "FTLCONF_webserver_port=999"'])
+@pytest.mark.parametrize("test_args", ['-e "FTLCONF_webserver.port=999"'])
 def test_ftlconf_webserver_port(docker):
     func = docker.run(CMD_APPLY_FTL_CONFIG_FROM_ENV)
     assert "Applied pihole-FTL setting webserver.port=999" in func.stdout
 
 
 @pytest.mark.parametrize(
-    "test_args", ['-e "FTLCONF_dns_upstreams=1.1.1.1;8.8.8.8#1234"']
+    "test_args", ['-e "FTLCONF_dns.upstreams=1.1.1.1;8.8.8.8#1234"']
 )
 def test_ftlconf_dns_upstreams(docker):
     func = docker.run(CMD_APPLY_FTL_CONFIG_FROM_ENV)


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

As an alternative to https://github.com/pi-hole/docker-pi-hole/pull/1456

In this case, rather than the user having to manually replace `.`'s with `_`s in the env var name (e.g `dns.upstreams` becomes `FTLCONF_dns_upstreams`), with this proposed change, they can now pass it in with the `.`s (e.g `dns.upsteams` becomes `FTLCONF_dns.upstreams`)

The advantage of doing this is that we don't have to add in a special case to handle FTL config names that have `_`s built into them as and when they are added.

The disadvantage of this is that merging this change _will_ break any existing `development-v6` containers that are running in userland.

Discuss

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_