### PR TITLE
Allow overwriting of downloaded FTL binary at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ var-log/
 
 # WIP/test stuff
 doco.yml
+
+src/pihole-FTL

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -70,6 +70,11 @@ RUN cd /etc/.pihole && \
 COPY --chmod=0755 bash_functions.sh /usr/bin/bash_functions.sh
 COPY --chmod=0755 start.sh /usr/bin/start.sh
 
+# Overwrite pihole-FTL binary from src directory if it exists
+# Useful for testing local builds of pihole-FTL prior to the CI build completing
+# See: https://stackoverflow.com/a/46801962
+COPY --chmod=0755 pihole-FT[L] /usr/bin/pihole-FTL
+
 HEALTHCHECK CMD dig +short +norecurse +retry=0 @127.0.0.1 pi.hole || exit 1
 
 ENTRYPOINT ["/sbin/tini", "--", "start.sh"]


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Mostly for easier local testing, rather than waiting for GHA to complete the build for a new branch of FTL, we can simply place a locally built binary into the /src directory and use it in the container.

If the binary does not exist the `COPY` step does not complain due to name matching:

https://stackoverflow.com/a/46801962

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_