### PR TITLE
Add idn2-utils to image as it is needed for pihole -q

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -20,6 +20,7 @@ RUN apk add --no-cache \
     curl \
     git \
     iproute2-ss \
+    idn2-utils \
     jq \
     libcap \
     ncurses \


### PR DESCRIPTION
As the title says. Fixes a bug reported here: 
https://github.com/pi-hole/pi-hole/issues/5458#issuecomment-1783729929