### PR TITLE
Only run gravity on boot _if_ the gravity database does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ To explicitly set no password, set `FTLCONF_webserver_api_password: ''`
 | Variable | Default | Value | Description |
 | -------- | ------- | ----- | ---------- |
 | `TAIL_FTL_LOG` | unset | `<unset\|1>` | Whether or not to output the FTL log when running the. Useful for debugging/watching what FTL is doing.
-| `SKIPGRAVITYONBOOT` | unset | `<unset\|1>` | Use this option to skip updating the Gravity Database when booting up the container.  By default this environment variable is not set so the Gravity Database will be updated when the container starts up.  Setting this environment variable to 1 (or anything) will cause the Gravity Database to not be updated when container starts up.
 | `FTLCONF_[SETTING]` | unset | As per documentation | Customize pihole.toml with settings described in the <!!!Add Link To New API docs here before release!!!>. Replace `.` with `_`, e.g for `dns.dnssec=true` use `FTLCONF_dns_dnssec: 'true'`<br/> Array type configs should be delimited with `;`|
 | `PIHOLE_UID` | `100` | Number | Overrides image's default pihole user id to match a host user id<br/>**IMPORTANT**: id must not already be in use inside the container! |
 | `PIHOLE_GID` | `101` | Number | Overrides image's default pihole group id to match a host group id<br/>**IMPORTANT**: id must not already be in use inside the container!|

--- a/src/start.sh
+++ b/src/start.sh
@@ -83,21 +83,12 @@ start() {
   gravityDBfile=$(getFTLConfigValue files.gravity)
 
   if [ ! -f "${gravityDBfile}" ]; then
-    if [ -n "${SKIPGRAVITYONBOOT}" ]; then
-      echo "  SKIPGRAVITYONBOOT is set, however ${gravityDBfile} does not exist (Likely due to a fresh volume). This is a required file for Pi-hole to operate."
-      echo "  Ignoring SKIPGRAVITYONBOOT on this occasion."
-      unset SKIPGRAVITYONBOOT
-    fi
+    echo "  [i] ${gravityDBfile} does not exist (Likely due to a fresh volume). This is a required file for Pi-hole to operate."
+    pihole -g
   else
     # TODO: Revisit this path if we move to a multistage build
     source /etc/.pihole/advanced/Scripts/database_migration/gravity-db.sh
     upgrade_gravityDB "${gravityDBfile}" "/etc/pihole"
-  fi
-
-  if [ -n "${SKIPGRAVITYONBOOT}" ]; then
-    echo "  [i] Skipping Gravity Database Update."
-  else
-    pihole -g
   fi
 
   pihole updatechecker


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

The sensible default for `SKIPGRAVITYONBOOT` should actually be `1`, as there isn't really any need to run gravity on every boot - `cron` handles that for us on a weekly basis.

Rather than changing the default, we simply remove the flag altogether, and only run gravity in cases where the gravity database does not exist (e.g in the case of a fresh volume)

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_