### PR TITLE
Allow setting an additional command to run on container start

### DIFF
--- a/src/start.sh
+++ b/src/start.sh
@@ -4,6 +4,14 @@ if [ "${PH_VERBOSE:-0}" -gt 0 ]; then
   set -x
 fi
 
+# Undocumented environment variable to allow easy injection of arbitrary commands.
+# HERE BE DRAGONS!
+# Example use case: If mounting the web repo from the host, we need to run `git config --global --add safe.directory /var/www/html/admin`
+#                   in order for the updatechecker to work
+if [ -n "${ADDITIONAL_COMMAND}" ]; then
+  eval "${ADDITIONAL_COMMAND}"
+fi
+
 trap stop TERM INT QUIT HUP ERR
 
 start() {


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

I'm not 100% sure on this one, but I'm not going to throw the idea away immediately without first some discussion around it.

My main use case is per the comments added in `start.sh`, namely:

```bash
# Example use case: If mounting the web repo from the host, we need to run `git config --global --add safe.directory /var/www/html/admin`
#                   in order for the updatechecker to work
```

By setting `ADDITIONAL_COMMAND: "git config --global --add safe.directory /var/www/html/admin"`, I can then bypass the following message when mounting into `/var/www/html/admin`. This is not a common occurrence in userland, so seems silly to run that command regardless (though, potentially OK?)

![image](https://github.com/pi-hole/docker-pi-hole/assets/1998970/e65e6074-d838-4370-b488-97b981f5f8c3)

Also allows for silly things like

![image](https://github.com/pi-hole/docker-pi-hole/assets/1998970/ffa70336-59bf-4b66-a649-ea89a6b24683)


I don't think this is a variable that needs documenting. Or maybe it does. Discuss.


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_