### PR TITLE
drop the `/v8` from `linux/arm64/v8`

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         registry: [dockerhub, ghcr]
-        platform: [linux/amd64, linux/386, linux/arm/v6, linux/arm/v7, linux/arm64/v8]
+        platform: [linux/amd64, linux/386, linux/arm/v6, linux/arm/v7, linux/arm64]
         container: [3.18]
         include:
           - registry: dockerhub

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
         # Official docker images for docker are only available for amd64 and arm64
         # TODO: Look at: https://github.com/docker-library/official-images#architectures-other-than-amd64
         # Is testing on all platforms really necessary?
-        platform: [linux/amd64, linux/arm64/v8]
+        platform: [linux/amd64, linux/arm64]
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

CI is using `linux/arm64/v8` in the `platform` matrix, we should be using `linux/arm64`. I think. Lets see what the tests say...

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_