### PR TITLE
Install logrotate

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -22,6 +22,7 @@ RUN apk add --no-cache \
     iproute2-ss \
     jq \
     libcap \
+    logrotate \
     ncurses \
     nmap-ncat \
     procps-ng \
@@ -62,7 +63,8 @@ RUN cd /etc/.pihole && \
     install -Dm755 -t /opt/pihole ./advanced/Scripts/*.sh && \
     install -Dm755 -t /opt/pihole ./advanced/Scripts/COL_TABLE && \
     install -Dm755 -d /etc/pihole && \
-    install -Dm755 -t /etc/pihole ./advanced/Templates/logrotate && \
+    install -Dm644 -t /etc/pihole ./advanced/Templates/logrotate && \
+    install -Dm755 -d /var/log/pihole && \
     install -Dm755 -t /usr/local/bin pihole && \
     install -Dm644 ./advanced/bash-completion/pihole /etc/bash_completion.d/pihole && \
     install -T -m 0755 ./advanced/Templates/pihole-FTL-prestart.sh /opt/pihole/pihole-FTL-prestart.sh && \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -61,6 +61,8 @@ RUN cd /etc/.pihole && \
     install -Dm755 -t /opt/pihole gravity.sh && \
     install -Dm755 -t /opt/pihole ./advanced/Scripts/*.sh && \
     install -Dm755 -t /opt/pihole ./advanced/Scripts/COL_TABLE && \
+    install -Dm755 -d /etc/pihole && \
+    install -Dm755 -t /etc/pihole ./advanced/Templates/logrotate && \
     install -Dm755 -t /usr/local/bin pihole && \
     install -Dm644 ./advanced/bash-completion/pihole /etc/bash_completion.d/pihole && \
     install -T -m 0755 ./advanced/Templates/pihole-FTL-prestart.sh /opt/pihole/pihole-FTL-prestart.sh && \

--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -36,9 +36,6 @@ setFTLConfigValue() {
 ensure_basic_configuration() {
     echo "  [i] Ensuring basic configuration by re-running select functions from basic-install.sh"
 
-    # TODO:
-    # installLogrotate || true #installLogRotate can return 2 or 3, but we are still OK to continue in that case
-
     mkdir -p /var/run/pihole /var/log/pihole
     touch /var/log/pihole/FTL.log /var/log/pihole/pihole.log
     chown -R pihole:pihole /var/run/pihole /var/log/pihole

--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -43,7 +43,6 @@ ensure_basic_configuration() {
     touch /var/log/pihole/FTL.log /var/log/pihole/pihole.log
     chown -R pihole:pihole /var/run/pihole /var/log/pihole
 
-    mkdir -p /etc/pihole
     if [[ -z "${PYTEST}" ]]; then
         if [[ ! -f /etc/pihole/adlists.list ]]; then
             echo "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts" >/etc/pihole/adlists.list


### PR DESCRIPTION
When starting with an empty `/etc/pihole`, docker startup errors with 

```
pihole  |   [i] Applying the following caps to pihole-FTL:
pihole  |         * CAP_CHOWN
pihole  |         * CAP_NET_BIND_SERVICE
pihole  |         * CAP_NET_RAW
pihole  | 
pihole  | chown: cannot access '/etc/pihole/logrotate': No such file or directory
pihole  | chmod: cannot access '/etc/pihole/logrotate': No such file or directory

```

Reason is, that `/etc/pihole/logrotate` does not exit, but `pihole-FTL.prestart.sh` tries to change owner/permissions.
This PR copies the file from the repo into the image.