### PR TITLE
Add pip ecosystem to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,16 @@ updates:
     target-branch: dev
     reviewers:
       - "pi-hole/docker-maintainers"
+  - package-ecosystem: pip
+    directory: "/test"
+    schedule:
+      interval: weekly
+      day: saturday
+      time: "10:00"
+    open-pull-requests-limit: 10
+    target-branch: dev
+    reviewers:
+      - "pi-hole/docker-maintainers"
   # Maintain dependencies for GitHub Actions development-v6
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -35,6 +45,16 @@ updates:
       interval: "weekly"
       day: saturday
       time: "10:00"
+    target-branch: development-v6
+    reviewers:
+      - "pi-hole/docker-maintainers"
+  - package-ecosystem: pip
+    directory: "/test"
+    schedule:
+      interval: weekly
+      day: saturday
+      time: "10:00"
+    open-pull-requests-limit: 10
     target-branch: development-v6
     reviewers:
       - "pi-hole/docker-maintainers"


### PR DESCRIPTION
As the title says: dependabot should watch the `pip` dependencies of our python test suite both on `dev` and `development-v6`.

PR targets `master` branch!