### PR TITLE
Create dir for logrotate statefile

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -65,6 +65,7 @@ RUN cd /etc/.pihole && \
     install -Dm755 -d /etc/pihole && \
     install -Dm644 -t /etc/pihole ./advanced/Templates/logrotate && \
     install -Dm755 -d /var/log/pihole && \
+    install -Dm755 -d /var/lib/logrotate && \
     install -Dm755 -t /usr/local/bin pihole && \
     install -Dm644 ./advanced/bash-completion/pihole /etc/bash_completion.d/pihole && \
     install -T -m 0755 ./advanced/Templates/pihole-FTL-prestart.sh /opt/pihole/pihole-FTL-prestart.sh && \


### PR DESCRIPTION
Fixes https://github.com/pi-hole/docker-pi-hole/pull/1470.

Executing `logrotate` will use a [statefile for the log](https://github.com/pi-hole/pi-hole/blob/4c129afb1046bcc02ce2de0274732f8beb26eff4/advanced/Scripts/piholeLogFlush.sh#L14-L17), but the used directory does not exit. `logrotate` fails therefore.

```
91c9a23456c:/# pihole -f once
  [i] Flushing /var/log/pihole/pihole.log ...error: error creating stub state file /var/lib/logrotate/pihole: No such file or directory
  [✓] Flushed /var/log/pihole/pihole.log
  [✓] Deleted  queries from database

```

Fixing this by creating the dir on image creation. 