### PR TITLE
install the logrotate file into /etc/pihole at startup in case of volume mounting

### DIFF
--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -40,6 +40,7 @@ ensure_basic_configuration() {
     touch /var/log/pihole/FTL.log /var/log/pihole/pihole.log
     chown -R pihole:pihole /var/run/pihole /var/log/pihole
 
+
     if [[ -z "${PYTEST}" ]]; then
         if [[ ! -f /etc/pihole/adlists.list ]]; then
             echo "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts" >/etc/pihole/adlists.list
@@ -54,6 +55,11 @@ ensure_basic_configuration() {
         setFTLConfigValue "files.macvendor" "/macvendor.db"
         chown pihole:pihole /macvendor.db
     fi
+
+    # Install the logrotate config file - this is done already in Dockerfile
+    # but if a user has mounted a volume over /etc/pihole, it will have been lost
+    # pihole-FTL-prestart.sh will set the ownership of the file to root:root
+    install -Dm644 -t /etc/pihole /etc/.pihole/advanced/Templates/logrotate
 }
 
 setup_web_password() {


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Per title. #1470 took care of this in the image - but we forgot to account for the `/etc/pihole` volume being mounted to the host on container start. This PR adds the same install command to the `ensure_basic_configuration` function.

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_