### PR TITLE
Enhance theme validation

### DIFF
--- a/src/s6/debian-root/usr/local/bin/bash_functions.sh
+++ b/src/s6/debian-root/usr/local/bin/bash_functions.sh
@@ -416,19 +416,16 @@ setup_web_port() {
 }
 
 setup_web_theme(){
-    # Parse the WEBTHEME variable, if it exists, and set the selected theme if it is one of the supported values.
-    # If an invalid theme name was supplied, setup WEBTHEME to use the default-light theme.
+    # Parse the WEBTHEME variable, if it exists, and set the selected theme if it is one of the supported values (i.e. it is one of the existing theme
+    # file names and passes a regexp sanity check). If an invalid theme name was supplied, setup WEBTHEME to use the default-light theme.
     if [ -n "${WEBTHEME}" ]; then
-        case "${WEBTHEME}" in
-        "default-dark" | "default-darker" | "default-light" | "default-auto" | "high-contrast" | "high-contrast-dark" | "lcars")
-            echo "  [i] Setting Web Theme based on WEBTHEME variable, using value ${WEBTHEME}"
-            change_setting "WEBTHEME" "${WEBTHEME}"
-            ;;
-        *)
-            echo "  [!] Invalid theme name supplied: ${WEBTHEME}, falling back to default-light."
-            change_setting "WEBTHEME" "default-light"
-            ;;
-        esac
+      if grep -qf <(find /var/www/html/admin/style/themes/ -type f -printf '%f\n' | sed -ne 's/^\([a-zA-Z0-9_-]\+\)\.css$/\1/gp') -xF - <<< "${WEBTHEME}"; then
+        echo "  [i] Setting Web Theme based on WEBTHEME variable, using value ${WEBTHEME}"
+        change_setting "WEBTHEME" "${WEBTHEME}"
+      else
+        echo "  [!] Invalid theme name supplied: ${WEBTHEME}, falling back to default-light."
+        change_setting "WEBTHEME" "default-light"
+      fi
     fi
 }
 


### PR DESCRIPTION
Makes the web theme name validation dynamic based on the existing theme css file names and applies a regexp sanity check just to be sure.

## Description
Modified bash_funcitons.sh:setup_web_theme.sh to replace static web theme name validation with dynamic one in order to make the validation future proof.

## Motivation and Context
Adding new themes requires modification of the validation function. This change modifies the validation code so that it accepts every theme that exists in the file system location.
Example: currently the recently-added lcars-picard theme is not accepted by the validation function because it has not been explicitly added to the validation code. This code change fixes that.

## How Has This Been Tested?
Ran standalone unit tests on the extracted setup_web_theme function. Added tests to the test suite. Added test fixture that temporarily creates empty theme files during the tests for the purpose of testing new known names.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [?] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
