### PR TITLE
Fix v6 build on riscv64

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -18,14 +18,14 @@ jobs:
       matrix:
         registry: [dockerhub, ghcr]
         platform: [linux/amd64, linux/386, linux/arm/v6, linux/arm/v7, linux/arm64]
-        container: [3.18]
+        alpine_version: [3.19]
         include:
           - registry: dockerhub
             platform: linux/riscv64
-            container: edge
+            alpine_version: edge
           - registry: ghcr
             platform: linux/riscv64
-            container: edge
+            alpine_version: edge
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -65,7 +65,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           build-args: |
             PIHOLE_DOCKER_TAG=${{ steps.meta.outputs.version }}
-            CONTAINER=${{ matrix.container }}
+            alpine_version=${{ matrix.alpine_version }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: |
             type=image,name=${{ env[matrix.registry] }},push-by-digest=true,name-canonical=true,push=true


### PR DESCRIPTION
https://github.com/pi-hole/docker-pi-hole/pull/1497 changed the base alpine version of the docker image to `3.19`. 
In this PR I also renamed the build-arg from `container` to `alpine_version`. However, I did not adjust the workflow file - so the `riscv64` [builds failed ](https://github.com/pi-hole/docker-pi-hole/actions/runs/7300747174/job/19896020464) because there is no `3.19` but only `edge`

https://hub.docker.com/r/riscv64/alpine/