### PR TITLE
Consider registry when up/downloading artifacts

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ env.PLATFORM_PAIR }}
+          name: digests-${{ matrix.registry }}-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -107,8 +107,8 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
-          path: /tmp/digests
-          pattern: digests-*
+          path: /tmp/digests/${{ matrix.registry }}
+          pattern: digests-${{ matrix.registry }}-*
           merge-multiple: true
       
       - name: Set up Docker Buildx


### PR DESCRIPTION
Include the used registry in the artifact upload name and separate downloads for registries. This hopefully fixes the issue we saw here: https://github.com/pi-hole/docker-pi-hole/actions/runs/7431563473