### PR TITLE
Add dockerfile frontend syntax line

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 ARG alpine_version="3.19"
 FROM alpine:${alpine_version}
 # https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope


### PR DESCRIPTION
Specifies the docker builder "fontend" to be on the latest version. See https://www.bretfisher.com/cloud-native-devops-36/.
In the future we might want to use some dockerfile features that are not available on older versions installed on the GH runners, so this line takes care of this.

(P.S. I wanted to use `ADD git@github` feature from[ frontend v1.6 ](https://docs.docker.com/engine/reference/builder/#adding-a-git-repository-add-git-ref-dir) to remove `git` from the dependency list, but noticed we need git to check for updated even in the container)