### PR TITLE
Fix README quickstart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ services:
       - NET_ADMIN # Required if you are using Pi-hole as your DHCP server, else not needed
     restart: unless-stopped
 ```
-2. Run `docker compose up -d` to build and start pi-hole (Syntax may be `docker-compose` on older systems)
+2. Run `docker-compose up -d` to build and start pi-hole (Syntax may be `docker-compose` on older systems)
 3. Use the Pi-hole web UI to change the DNS settings *Interface listening behavior* to "Listen on all interfaces, permit all origins", if using Docker's default `bridge` network setting. (This can also be achieved by setting the environment variable `DNSMASQ_LISTENING` to `all`)
 
 [Here is an equivalent docker run script](https://github.com/pi-hole/docker-pi-hole/blob/master/examples/docker_run.sh).


### PR DESCRIPTION
The command in quickstart to init docker-compose is wrong.

## Description
Change `docker compose up -d` to `docker-compose up -d`

## Motivation and Context
People who don't know how to code can get stuck in this step

## How Has This Been Tested?
NA