### PR TITLE
Fix: correct dns upstreams `FTLCONF_dns_upstreams` variable name

### DIFF
--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -65,7 +65,7 @@ ensure_basic_configuration() {
     if [[ $(getFTLConfigValue "dns.upstreams") == "[]" ]]; then
         echo ""
         echo "  [X] No DNS upstream servers are set!"
-        echo "  [i] Recommended: Set the upstream DNS servers in the environment variable FTLCONF_dns_upstream"
+        echo "  [i] Recommended: Set the upstream DNS servers in the environment variable FTLCONF_dns_upstreams"
         echo ""
         exit 1
     fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I couldn't figure out why the container wasnt starting because the log output says to use `FTLCONF_dns_upstream` (missing the `s`) which was pretty confusing 😅, I think its just a typo

## Motivation and Context
Error suggests setting an incorrect environment variable

## How Has This Been Tested?
This compose fails and gives the output:

<img width="944" alt="Screenshot 2024-03-28 at 11 34 03 AM" src="https://github.com/pi-hole/docker-pi-hole/assets/4887959/7e46deb4-2b09-4550-bc1e-b12301c41e02">


```yaml
  piholev6:
      container_name: piholev6
      image: pihole/pihole:development-v6
      ports:
        - "53:53/tcp"
        - "53:53/udp"
        - "80:80/tcp"
      environment:
        TZ: 'America/Los_Angeles'
        FTLCONF_webserver_api_password: thisisapassword
        FTLCONF_dns_upstream: 8.8.8.8;1.1.1.1
        FTLCONF_dns_listeningMode: all
```

Verified the variable name at https://ftl.pi-hole.net/development-v6/docs/#get-/config and of course it makes the docker container run



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
