### PR TITLE
Remove obsolete "version" value from example docker-compose.yml files

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ Using [Docker-compose](https://docs.docker.com/compose/install/):
 
 
 ```yml
-version: "3"
-
 # More info at https://github.com/pi-hole/docker-pi-hole/ and https://docs.pi-hole.net/
 services:
   pihole:

--- a/examples/docker-compose-caddy-proxy.yml
+++ b/examples/docker-compose-caddy-proxy.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
 
   # Caddy example derived from Caddy's own example at https://hub.docker.com/_/caddy


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove obsolete "version" value from example docker-compose.yml in README.md and from `examples/docker-compose-caddy-proxy.yml` since "Compose doesn't use version to select an exact schema to validate the Compose file, but prefers the most recent schema when it's implemented."
## Motivation and Context
Fixes issue #1562.

## How Has This Been Tested?
Viewed `README.md` and verified that `Version` is no longer specified in the example `docker-compose.yml`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
