### PR TITLE
Install grep to avoid issues in pihole -w/b with the default busybox …

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -21,6 +21,8 @@ RUN apk add --no-cache \
     coreutils \
     curl \
     git \
+    # Install grep to avoid issues in pihole -w/b with the default busybox grep
+    grep \
     iproute2-ss \
     jq \
     libcap \
@@ -34,7 +36,7 @@ RUN apk add --no-cache \
     tini \
     tzdata \
     unzip \
-    wget
+    wget 
 
 ADD https://ftl.pi-hole.net/macvendor.db /macvendor.db
 COPY crontab.txt /crontab.txt


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Fixes https://github.com/pi-hole/docker-pi-hole/issues/1577 by replacing `busybox`'s `grep` - which does not include the `P` option

Before:
```text
dev-v6:/# pihole -b test.com
grep: unrecognized option: P
BusyBox v1.36.1 (2023-11-07 18:53:09 UTC) multi-call binary.

Usage: grep [-HhnlLoqvsrRiwFE] [-m N] [-A|B|C N] { PATTERN | -e PATTERN... | -f FILE... } [FILE]...

Search for PATTERN in FILEs (or stdin)

        -H      Add 'filename:' prefix
        -h      Do not add 'filename:' prefix
        -n      Add 'line_no:' prefix
        -l      Show only names of files that match
        -L      Show only names of files that don't match
        -c      Show only count of matching lines
        -o      Show only the matching part of line
        -q      Quiet. Return 0 if PATTERN is found, 1 otherwise
        -v      Select non-matching lines
        -s      Suppress open and read errors
        -r      Recurse
        -R      Recurse and dereference symlinks
        -i      Ignore case
        -w      Match whole words only
        -x      Match whole lines only
        -F      PATTERN is a literal (not regexp)
        -E      PATTERN is an extended regexp
        -m N    Match up to N times per file
        -A N    Print N lines of trailing context
        -B N    Print N lines of leading context
        -C N    Same as '-A N -B N'
        -e PTRN Pattern to match
        -f FILE Read pattern from file
grep: unrecognized option: P
BusyBox v1.36.1 (2023-11-07 18:53:09 UTC) multi-call binary.

Usage: grep [-HhnlLoqvsrRiwFE] [-m N] [-A|B|C N] { PATTERN | -e PATTERN... | -f FILE... } [FILE]...

Search for PATTERN in FILEs (or stdin)

        -H      Add 'filename:' prefix
        -h      Do not add 'filename:' prefix
        -n      Add 'line_no:' prefix
        -l      Show only names of files that match
        -L      Show only names of files that don't match
        -c      Show only count of matching lines
        -o      Show only the matching part of line
        -q      Quiet. Return 0 if PATTERN is found, 1 otherwise
        -v      Select non-matching lines
        -s      Suppress open and read errors
        -r      Recurse
        -R      Recurse and dereference symlinks
        -i      Ignore case
        -w      Match whole words only
        -x      Match whole lines only
        -F      PATTERN is a literal (not regexp)
        -E      PATTERN is an extended regexp
        -m N    Match up to N times per file
        -A N    Print N lines of trailing context
        -B N    Print N lines of leading context
        -C N    Same as '-A N -B N'
        -e PTRN Pattern to match
        -f FILE Read pattern from file
  [✗] test.com is not a valid argument or domain name!
``` 

After:

```bash
dev-v6:/# pihole -b test.com
  [i] Adding test.com to the blacklist...
  [✓] Reloading DNS lists
```

![image](https://github.com/pi-hole/docker-pi-hole/assets/1998970/451ba882-dea0-46fe-bff4-f0458a2b9bf9)


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_