### PR TITLE
Update DOCKER_BUILD_CMD in build.sh to include the "--load" flag

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ usage() {
 }
 
 # Set default values
-DOCKER_BUILD_CMD="docker buildx build src/. --tag pihole --no-cache"
+DOCKER_BUILD_CMD="docker buildx build src/. --tag pihole --load --no-cache"
 FTL_FLAG=false
 
 # Parse command line arguments


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Prevent this from happening:

![image](https://github.com/pi-hole/docker-pi-hole/assets/1998970/f75ce196-ec2d-4c90-bc94-602e10f9ac3b)

See: https://stackoverflow.com/questions/74707530/docker-buildx-fails-to-show-result-in-image-list

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_