### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@
 [Docker-compose](https://docs.docker.com/compose/install/) example:
 
 ```yaml
-version: "3"
 
 # More info at https://github.com/pi-hole/docker-pi-hole/ and https://docs.pi-hole.net/
 services:


### PR DESCRIPTION
version: "3' is not longer needed in docker-compose.yml

`{Please select 'base: dev' as target branch above! (you can delete this line)}`

<!--- Provide a general summary of your changes in the Title above -->

## Description
I just removed the link version: "3" as it is deprecated by recent docker versions.

## Motivation and Context
This allows the compose file to be much more concise since unnecessary lines are removed.

## How Has This Been Tested?
This edited compose file has been used on multiple systems for the past few months on various systems (around 5 systems with mostly ubuntu server and Debian)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
