### PR TITLE
Use correct delimeter in example compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ services:
       # Set a password to access the web interface. Not setting one will result in a random password being assigned
       FTLCONF_webserver_api_password: 'correct horse battery staple'
       # Configure DNS upstream servers, e.g:
-      FTLCONF_dns_upstreams: '8.8.8.8, 8.8.4.4'
+      FTLCONF_dns_upstreams: '8.8.8.8;8.8.4.4'
     # Volumes store your data between container upgrades
     volumes:
       # For persisting Pi-hole's databases and common configuration file

--- a/examples/docker-compose-caddy-proxy.yml
+++ b/examples/docker-compose-caddy-proxy.yml
@@ -37,7 +37,7 @@ services:
       # Set a password to access the web interface. Not setting one will result in a random password being assigned
       FTLCONF_webserver_api_password: 'correct horse battery staple'
       # Configure DNS upstream servers, e.g:
-      FTLCONF_dns_upstreams: '8.8.8.8, 8.8.4.4'
+      FTLCONF_dns_upstreams: '8.8.8.8;8.8.4.4'
     # Volumes store your data between container upgrades
     volumes:
       # For persisting Pi-hole's databases and common configuration file


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Readme and example file both have the wrong delimeter for `FTLCONF_dns_upstreams`, should be a `;` Simple fix!

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_