### PR TITLE
[v5] Fix architecture detection for linux/386 images

### DIFF
--- a/src/s6/debian-root/usr/local/bin/install.sh
+++ b/src/s6/debian-root/usr/local/bin/install.sh
@@ -17,9 +17,15 @@ detect_arch() {
     S6_ARCH="armhf";;
   armv7l)
     S6_ARCH="armhf";;
-  i386)
-    S6_ARCH="i686";;
-esac
+  x86_64)
+    # arch returns x86_64 on linux/i386, causing the wrong s6-overlay to be downloaded
+    # fallback to dpkg to check the architecture and download the i686 s6-overlay if necessary
+    # see https://github.com/pi-hole/docker-pi-hole/issues/1524 for more information
+    ARCH_CHECK=$(dpkg --print-architecture)
+    if [ "$ARCH_CHECK" == "i386" ]; then
+      S6_ARCH="i686"
+    fi    
+  esac
 }
 
 


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Fixes https://github.com/pi-hole/docker-pi-hole/issues/1524

`arch` returns `x86_64` when using `--platform=linux/386` with the docker build command, whereas `dpkg --print-architecture` returns `i386`

Interestingly, building the image on an actual 32 bit machine does not show the same behaviour, so I guess this is an issue with `docker build`. No matter, this will work for now and will allow people to use `:latest` on 32-bit hosts if they wish. (v6 has no such issue)

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_