### PR TITLE
Add support for choosing PADD branch in build script

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
       with:
-        platforms: ${{ matrix.platform}}
+        platforms: ${{ matrix.platform }}
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -27,4 +27,4 @@ jobs:
     - name: Run Tests
       run: |
         echo "Building image to test"
-        PLATFORM=${{ matrix.platform}} ./build-and-test.sh
+        PLATFORM=${{ matrix.platform }} ./build-and-test.sh

--- a/build-and-test.sh
+++ b/build-and-test.sh
@@ -2,7 +2,8 @@
 set -ex
 
 if [[ "$1" == "enter" ]]; then
-    enter="-it --entrypoint=sh"
+    enter="-it"
+    cmd="sh"
 fi
 
 GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD | sed "s/\//-/g")
@@ -20,4 +21,4 @@ docker run --rm \
     --env GIT_TAG="${GIT_TAG}" \
     --env PY_COLORS=1 \
     --env TARGETPLATFORM="${PLATFORM}" \
-    ${enter} image_pipenv
+    ${enter} image_pipenv ${cmd}

--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,7 @@ usage() {
     echo "  -f, --ftlbranch <branch>     Specify FTL branch (cannot be used in conjunction with -l)"
     echo "  -c, --corebranch <branch>    Specify Core branch"
     echo "  -w, --webbranch <branch>     Specify Web branch"
+    echo "  -p, --paddbranch <branch>    Specify PADD branch"
     echo "  -t, --tag <tag>              Specify Docker image tag (default: pihole)"
     echo "  -l, --local                  Use locally built FTL binary (requires src/pihole-FTL file)"
     echo "  use_cache                    Enable caching (by default --no-cache is used)"
@@ -58,6 +59,12 @@ while [[ $# -gt 0 ]]; do
     -w | --webbranch)
         WEB_BRANCH="$2"
         DOCKER_BUILD_CMD+=" --build-arg WEB_BRANCH=$WEB_BRANCH"
+        shift
+        shift
+        ;;
+    -p | --paddbranch)
+        PADD_BRANCH="$2"
+        DOCKER_BUILD_CMD+=" --build-arg PADD_BRANCH=$PADD_BRANCH"
         shift
         shift
         ;;

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 ARG FTL_SOURCE=remote
 ARG alpine_version="3.19" 
-FROM alpine:${alpine_version} as base
+FROM alpine:${alpine_version} AS base
 # https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
 
 ARG TARGETPLATFORM
@@ -69,7 +69,7 @@ COPY --chmod=0755 start.sh /usr/bin/start.sh
 
 ## Buildkit can do some fancy stuff and we can use it to either download FTL from ftl.pi-hole.net or use a local copy
 
-FROM base as remote-ftl-install
+FROM base AS remote-ftl-install
 # Default stage if FTL_SOURCE is not explicitly set to "local"
 # Download the latest version of pihole-FTL for the correct architecture
 RUN if   [ "$TARGETPLATFORM" = "linux/amd64" ];    then FTLARCH=amd64; \
@@ -85,12 +85,12 @@ RUN if   [ "$TARGETPLATFORM" = "linux/amd64" ];    then FTLARCH=amd64; \
     && chmod +x /usr/bin/pihole-FTL \
     && readelf -h /usr/bin/pihole-FTL || cat /usr/bin/pihole-FTL
 
-FROM base as local-ftl-install
+FROM base AS local-ftl-install
 # pihole-FTL must be built from source and copied to the build directory first!
 COPY --chmod=0755 pihole-FTL /usr/bin/pihole-FTL
 
 # Use the appropriate FTL Install stage based on the FTL_SOURCE build-arg
-FROM ${FTL_SOURCE}-ftl-install as final
+FROM ${FTL_SOURCE}-ftl-install AS final
 
 HEALTHCHECK CMD dig +short +norecurse +retry=0 @127.0.0.1 pi.hole || exit 1
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -18,5 +18,5 @@ RUN apk add --no-cache \
     # Tests fall over without it. Investigate later.
     && sed -i 's|/bin/sh|/bin/bash|g' /usr/lib/python3.11/site-packages/testinfra/backend/docker.py
 
-ENTRYPOINT entrypoint.sh
-CMD cmd.sh
+ENTRYPOINT ["/bin/sh","-c","entrypoint.sh"]
+CMD ["/bin/sh","-c","cmd.sh"]

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -4,7 +4,6 @@ ARG docker_version="25.0.4"
 FROM docker:${docker_version}-cli-alpine${alpine_version}
 
 COPY --chmod=0755 ./cmd.sh /usr/local/bin/cmd.sh
-COPY --chmod=0755 ./entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY requirements.txt /root/
 WORKDIR /root
 
@@ -18,5 +17,5 @@ RUN apk add --no-cache \
     # Tests fall over without it. Investigate later.
     && sed -i 's|/bin/sh|/bin/bash|g' /usr/lib/python3.11/site-packages/testinfra/backend/docker.py
 
-ENTRYPOINT ["/bin/sh","-c","entrypoint.sh"]
-CMD ["/bin/sh","-c","cmd.sh"]
+SHELL ["/bin/sh", "-c"]
+CMD ["cmd.sh"]

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -1,1 +1,0 @@
-set -ex && cmd.sh

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,4 +1,4 @@
-pytest == 7.4.
+pytest == 7.4
 pytest-xdist == 3.5.0
 pytest-testinfra == 10.0.0
 black == 23.12.0


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

TItle. Also fixes casing of `as` -> `AS` in the Dockerfile which was prompted by:

```
 4 warnings found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 4)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 72)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 88)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 93)
```

Edit: Also fixes the currently failing builds on `development-v6` by removing a trailing `.` from the pytest version in requirements.txt. Not sure how it was working before, but the fix is simple

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_