### PR TITLE
Default DNS Upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,7 @@ services:
       # Set the appropriate timezone for your location (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), e.g:
       TZ: 'Europe/London'
       # Set a password to access the web interface. Not setting one will result in a random password being assigned
-      FTLCONF_webserver_api_password: 'correct horse battery staple'
-      # Configure DNS upstream servers, e.g:
-      FTLCONF_dns_upstreams: '8.8.8.8;8.8.4.4'
+      FTLCONF_webserver_api_password: 'correct horse battery staple'     
     # Volumes store your data between container upgrades
     volumes:
       # For persisting Pi-hole's databases and common configuration file

--- a/examples/docker-compose-caddy-proxy.yml
+++ b/examples/docker-compose-caddy-proxy.yml
@@ -35,9 +35,7 @@ services:
       # Set the appropriate timezone for your location (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), e.g:
       TZ: 'Europe/London'
       # Set a password to access the web interface. Not setting one will result in a random password being assigned
-      FTLCONF_webserver_api_password: 'correct horse battery staple'
-      # Configure DNS upstream servers, e.g:
-      FTLCONF_dns_upstreams: '8.8.8.8;8.8.4.4'
+      FTLCONF_webserver_api_password: 'correct horse battery staple'     
     # Volumes store your data between container upgrades
     volumes:
       # For persisting Pi-hole's databases and common configuration file

--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -62,12 +62,9 @@ ensure_basic_configuration() {
     fi
 
     # If getFTLConfigValue "dns.upstreams" returns [], exit the container. We need upstream servers to function!
-    if [[ $(getFTLConfigValue "dns.upstreams") == "[]" ]]; then
-        echo ""
-        echo "  [X] No DNS upstream servers are set!"
-        echo "  [i] Recommended: Set the upstream DNS servers in the environment variable FTLCONF_dns_upstreams"
-        echo ""
-        exit 1
+    if [[ $(getFTLConfigValue "dns.upstreams") == "[]" ]]; then                
+        echo "  [i] No DNS upstream set in environment or config file, defaulting to Google DNS"        
+        setFTLConfigValue "dns.upstreams" "[\"8.8.8.8\", \"8.8.4.4\"]"        
     fi
 
     setup_web_password

--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -61,7 +61,7 @@ ensure_basic_configuration() {
         chown pihole:pihole /macvendor.db
     fi
 
-    # If getFTLConfigValue "dns.upstreams" returns [], exit the container. We need upstream servers to function!
+    # If getFTLConfigValue "dns.upstreams" returns [], default to Google's DNS server
     if [[ $(getFTLConfigValue "dns.upstreams") == "[]" ]]; then                
         echo "  [i] No DNS upstream set in environment or config file, defaulting to Google DNS"        
         setFTLConfigValue "dns.upstreams" "[\"8.8.8.8\", \"8.8.4.4\"]"        

--- a/test/tests/test_general.py
+++ b/test/tests/test_general.py
@@ -14,14 +14,14 @@ def test_pihole_gid_env_var(docker):
 
 
 # Wait 5 seconds for startup, then kill the start.sh script
-# Finally, tail the FTL log to see if it has been shut down cleanly
+# Finally, grep the FTL log to see if it has been shut down cleanly
 def test_pihole_ftl_clean_shutdown(docker):
     func = docker.run(
         """
         sleep 5
         killall --signal 15 start.sh
         sleep 5
-        tail -f /var/log/pihole-FTL.log
+        grep 'jmpret\|terminated' /var/log/pihole/FTL.log
     """
     )
     assert "INFO: Shutting down... // exit code 0 // jmpret 0" in func.stdout


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

See https://discourse.pi-hole.net/t/how-to-modify-upstream-server-only-via-gui-on-v6/70943/13?u=promofaux

Lower the barrier to entry/reduce confusion by setting DNS upstreams to `8.8.8.8;8.8.4.4` if we detect that it has not already been set by either the environment variable or config file. Falling back to a default rather than hard-exiting is probably more user friendly, on reflection.


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_