### PR TITLE
Add pytest-clarity to test environment to improve error log output

### DIFF
--- a/test/cmd.sh
+++ b/test/cmd.sh
@@ -8,4 +8,4 @@ docker images pihole:${GIT_TAG}
 python -m black ./test/tests/
 
 # TODO: Add junitxml output and have something consume it
-py.test -vv -n auto ./test/tests/
+COLUMNS=120 py.test -vv -n auto ./test/tests/

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,3 +2,4 @@ pytest == 7.4
 pytest-xdist == 3.5.0
 pytest-testinfra == 10.0.0
 black == 23.12.0
+pytest-clarity == 1.0.1


### PR DESCRIPTION
We use `pytest` for testing. While it is very capable, its error output is a mess. Adding `pytest-clarity` improves on that (see https://github.com/darrenburns/pytest-clarity).

Before
![Screenshot at 2024-07-01 00-10-02](https://github.com/pi-hole/docker-pi-hole/assets/26622301/ccbea906-799e-4820-8401-35f110a34e15)


After
![Screenshot at 2024-07-01 00-09-46](https://github.com/pi-hole/docker-pi-hole/assets/26622301/25746354-1465-44ca-83ec-e06563bffb73)

___

Note: this PR needs https://github.com/pi-hole/docker-pi-hole/pull/1608/commits/99f459e30fe8a9fd8a8b40e99f3a41814d7a1078 to pass the tests
