### PR TITLE
Set default tag for locally build images to pihole:local

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,14 +216,14 @@ The preferred method is to clone this repository and build the image locally wit
 - `-f <branch>` /  `--ftlbranch <branch>`: Specify FTL branch (cannot be used in conjunction with `-l`)
 - `-c <branch>` / `--corebranch <branch>`: Specify Core branch
 - `-w <branch>` / `--webbranch <branch>`: Specify Web branch
-- `-t <tag>` / `--tag <tag>`: Specify Docker image tag (default: `pihole`)
+- `-t <tag>` / `--tag <tag>`: Specify Docker image tag (default: `pihole:local`)
 - `-l` / `--local`: Use locally built FTL binary (requires `src/pihole-FTL` file)
 - `use_cache`: Enable caching (by default `--no-cache` is used)
 
 If no options are specified, the following command will be executed:
 
 ```
-docker buildx build src/. --tag pihole --no-cache
+docker buildx build src/. --tag pihole:local --no-cache
 ```
 
 ### Pi-hole features

--- a/build.sh
+++ b/build.sh
@@ -8,17 +8,17 @@ usage() {
     echo "  -c, --corebranch <branch>    Specify Core branch"
     echo "  -w, --webbranch <branch>     Specify Web branch"
     echo "  -p, --paddbranch <branch>    Specify PADD branch"
-    echo "  -t, --tag <tag>              Specify Docker image tag (default: pihole)"
+    echo "  -t, --tag <tag>              Specify Docker image tag (default: pihole:local)"
     echo "  -l, --local                  Use locally built FTL binary (requires src/pihole-FTL file)"
     echo "  use_cache                    Enable caching (by default --no-cache is used)"
     echo ""
     echo "If no options are specified, the following command will be executed:"
-    echo "  docker buildx build src/. --tag pihole --load --no-cache"
+    echo "  docker buildx build src/. --tag pihole:local --load --no-cache"
     exit 1
 }
 
 # Set default values
-DOCKER_BUILD_CMD="docker buildx build src/. --tag pihole --load --no-cache"
+DOCKER_BUILD_CMD="docker buildx build src/. --tag pihole:local --load --no-cache"
 FTL_FLAG=false
 
 # Parse command line arguments
@@ -70,7 +70,7 @@ while [[ $# -gt 0 ]]; do
         ;;
     -t | --tag)
         TAG="$2"
-        DOCKER_BUILD_CMD=${DOCKER_BUILD_CMD/pihole/$TAG}
+        DOCKER_BUILD_CMD=${DOCKER_BUILD_CMD/pihole:local/$TAG}
         shift
         shift
         ;;


### PR DESCRIPTION
## Description
Set default tag for locally build images to pihole:local

## Motivation and Context
To better distinguish between upstream und locally build images

## How Has This Been Tested?
Yes.

```
chris@T14Gen5:~/Software/Pi-hole repositories/docker-pi-hole$ ./build.sh
Executing command: docker buildx build src/. --tag pihole:local --load --no-cache
[+] Building 14.5s (19/19) FINISHED                                                                                                       docker:default
 => [internal] load build definition from Dockerfile                                                                                                0.0s
 => => transferring dockerfile: 3.93kB                                                                                                              0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:1                                                                           1.3s
 => CACHED docker-image://docker.io/docker/dockerfile:1@sha256:fe40cf4e92cd0c467be2cfc30657a680ae2398318afd50b0c80585784c604f28                     0.0s
 => [internal] load metadata for docker.io/library/alpine:3.20                                                                                      0.9s
 => [internal] load .dockerignore                                                                                                                   0.0s
 => => transferring context: 82B                                                                                                                    0.0s
 => [internal] load build context                                                                                                                   0.0s
 => => transferring context: 10.80kB                                                                                                                0.0s
 => CACHED [base 1/9] FROM docker.io/library/alpine:3.20@sha256:0a4eaa0eecf5f8c050e5bba433f58c052be7587ee8af3e8b3910ef9ab5fbe9f5                    0.0s
 => [base 3/9] ADD https://ftl.pi-hole.net/macvendor.db /macvendor.db                                                                               0.9s
 => [base 5/9] ADD --chmod=0755 https://raw.githubusercontent.com/pi-hole/PADD/PADD_FTLv6/padd.sh /usr/local/bin/padd                               0.3s
 => [base 2/9] RUN apk add --no-cache     bash     bind-tools     binutils     coreutils     curl     git     grep     iproute2-ss     jq     libc  5.9s
 => [base 3/9] ADD https://ftl.pi-hole.net/macvendor.db /macvendor.db                                                                               0.0s
 => [base 4/9] COPY crontab.txt /crontab.txt                                                                                                        0.0s
 => [base 5/9] ADD --chmod=0755 https://raw.githubusercontent.com/pi-hole/PADD/PADD_FTLv6/padd.sh /usr/local/bin/padd                               0.0s
 => [base 6/9] RUN git clone --depth 1 --single-branch --branch development-v6 https://github.com/pi-hole/web.git /var/www/html/admin &&     git c  1.8s
 => [base 7/9] RUN cd /etc/.pihole &&     install -Dm755 -d /opt/pihole &&     install -Dm755 -t /opt/pihole gravity.sh &&     install -Dm755 -t /  0.2s
 => [base 8/9] COPY --chmod=0755 bash_functions.sh /usr/bin/bash_functions.sh                                                                       0.0s
 => [base 9/9] COPY --chmod=0755 start.sh /usr/bin/start.sh                                                                                         0.0s
 => [remote-ftl-install 1/1] RUN if   [ "linux/amd64" = "linux/amd64" ];    then FTLARCH=amd64;     elif [ "linux/amd64" = "linux/386" ];      the  3.8s
 => exporting to image                                                                                                                              0.2s
 => => exporting layers                                                                                                                             0.2s
 => => writing image sha256:edf6eb7d2db4d01a42eb1f8b524967f1d5db465bf47540446e4705d4e791d957                                                        0.0s
 => => naming to docker.io/library/pihole:local                                                                                                     0.0s
chris@T14Gen5:~/Software/Pi-hole repositories/docker-pi-hole$ docker images
REPOSITORY                                                                                      TAG               IMAGE ID       CREATED         SIZE
pihole                                                                                          local             edf6eb7d2db4   5 seconds ago   89.7MB
```

