### PR TITLE
Be more graceful when detecting a v5->v6 migration

### DIFF
--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -28,31 +28,108 @@ setFTLConfigValue() {
     pihole-FTL --config "${1}" "${2}" >/dev/null
 }
 
-# shellcheck disable=SC2034
-ensure_basic_configuration() {
-    # Force a check of pihole-FTL --config, this will read any environment variables and set them in the config file
-    # suppress the output as we don't need to see the default values.
-    getFTLConfigValue >/dev/null
+set_uid_gid() {
 
+    echo "  [i] Setting up user & group for the pihole user"
+
+    currentUid=$(id -u pihole)
+
+    # If PIHOLE_UID is set, modify the pihole group's id to match
+    if [ -n "${PIHOLE_UID}" ]; then
+        if [[ ${currentUid} -ne ${PIHOLE_UID} ]]; then
+            echo "  [i] Changing ID for user: pihole (${currentUid} => ${PIHOLE_UID})"
+            usermod -o -u ${PIHOLE_UID} pihole
+        else
+            echo "  [i] ID for user pihole is already ${PIHOLE_UID}, no need to change"
+        fi
+    else
+        echo "  [i] PIHOLE_UID not set in environment, using default (${currentUid})"
+    fi
+
+    currentGid=$(id -g pihole)
+
+    # If PIHOLE_GID is set, modify the pihole group's id to match
+    if [ -n "${PIHOLE_GID}" ]; then
+        if [[ ${currentGid} -ne ${PIHOLE_GID} ]]; then
+            echo "  [i] Changing ID for group: pihole (${currentGid} => ${PIHOLE_GID})"
+            groupmod -o -g ${PIHOLE_GID} pihole
+        else
+            echo "  [i] ID for group pihole is already ${PIHOLE_GID}, no need to change"
+        fi
+    else
+        echo "  [i] PIHOLE_GID not set in environment, using default (${currentGid})"
+    fi
     echo ""
-    echo "  [i] Ensuring basic configuration by re-running select functions from basic-install.sh"
+}
 
-    mkdir -p /var/run/pihole /var/log/pihole
-    touch /var/log/pihole/FTL.log /var/log/pihole/pihole.log
-    chown -R pihole:pihole /var/run/pihole /var/log/pihole
+install_additional_packages() {
+    if [ -n "${ADDITIONAL_PACKAGES}" ]; then
+        echo "  [i] Additional packages requested: ${ADDITIONAL_PACKAGES}"
+        echo "  [i] Fetching APK repository metadata."
+        if ! apk update; then
+            echo "  [i] Failed to fetch APK repository metadata."
+        else
+            echo "  [i] Installing additional packages: ${ADDITIONAL_PACKAGES}."
+            # shellcheck disable=SC2086
+            if ! apk add --no-cache ${ADDITIONAL_PACKAGES}; then
+                echo "  [i] Failed to install additional packages."
+            fi
+        fi
+        echo ""
+    fi
+}
+
+start_cron() {
+    echo "  [i] Starting crond for scheduled scripts. Randomizing times for gravity and update checker"
+    # Randomize gravity update time
+    sed -i "s/59 1 /$((1 + RANDOM % 58)) $((3 + RANDOM % 2))/" /crontab.txt
+    # Randomize update checker time
+    sed -i "s/59 17/$((1 + RANDOM % 58)) $((12 + RANDOM % 8))/" /crontab.txt
+    /usr/bin/crontab /crontab.txt
+
+    /usr/sbin/crond
+    echo ""
+}
+
+install_logrotate() {
+    # Install the logrotate config file - this is done already in Dockerfile
+    # but if a user has mounted a volume over /etc/pihole, it will have been lost
+    # pihole-FTL-prestart.sh will set the ownership of the file to root:root
+    echo "  [i] Ensuring logrotate script exists in /etc/pihole"
+    install -Dm644 -t /etc/pihole /etc/.pihole/advanced/Templates/logrotate
+    echo ""
+}
+
+migrate_gravity() {
+    echo "  [i] Gravity migration checks"
+    gravityDBfile=$(getFTLConfigValue files.gravity)
 
     if [[ -z "${PYTEST}" ]]; then
         if [[ ! -f /etc/pihole/adlists.list ]]; then
+            echo "  [i] No adlist file found, creating one with a default blocklist"
             echo "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts" >/etc/pihole/adlists.list
         fi
     fi
 
-    chown -R pihole:pihole /etc/pihole
+    if [ ! -f "${gravityDBfile}" ]; then
+        echo "  [i] ${gravityDBfile} does not exist (Likely due to a fresh volume). This is a required file for Pi-hole to operate."
+        echo "  [i] Gravity will now be run to create the database"
+        pihole -g
+    else
+        echo "  [i] Existing gravity database found"
+        # source the migration script and run the upgrade function
+        source /etc/.pihole/advanced/Scripts/database_migration/gravity-db.sh
+        upgrade_gravityDB "${gravityDBfile}" "/etc/pihole"
+    fi
+    echo ""
+}
 
-    # Install the logrotate config file - this is done already in Dockerfile
-    # but if a user has mounted a volume over /etc/pihole, it will have been lost
-    # pihole-FTL-prestart.sh will set the ownership of the file to root:root
-    install -Dm644 -t /etc/pihole /etc/.pihole/advanced/Templates/logrotate
+# shellcheck disable=SC2034
+ftl_config() {
+
+    # Force a check of pihole-FTL --config, this will read any environment variables and set them in the config file
+    # suppress the output as we don't need to see the default values.
+    getFTLConfigValue >/dev/null
 
     # If FTLCONF_files_macvendor is not set
     if [[ -z "${FTLCONF_files_macvendor:-}" ]]; then
@@ -62,9 +139,9 @@ ensure_basic_configuration() {
     fi
 
     # If getFTLConfigValue "dns.upstreams" returns [], default to Google's DNS server
-    if [[ $(getFTLConfigValue "dns.upstreams") == "[]" ]]; then                
-        echo "  [i] No DNS upstream set in environment or config file, defaulting to Google DNS"        
-        setFTLConfigValue "dns.upstreams" "[\"8.8.8.8\", \"8.8.4.4\"]"        
+    if [[ $(getFTLConfigValue "dns.upstreams") == "[]" ]]; then
+        echo "  [i] No DNS upstream set in environment or config file, defaulting to Google DNS"
+        setFTLConfigValue "dns.upstreams" "[\"8.8.8.8\", \"8.8.4.4\"]"
     fi
 
     setup_web_password
@@ -74,7 +151,7 @@ setup_web_password() {
     # If FTLCONF_webserver_api_password is not set
     if [ -z "${FTLCONF_webserver_api_password+x}" ]; then
         # Is this already set to something other than blank (default) in FTL's config file? (maybe in a volume mount)
-        if [[ $(pihole-FTL --config webserver.api.pwhash) = \$BALLOON-SHA256* ]]; then
+        if [[ $(pihole-FTL --config webserver.api.pwhash) ]]; then
             echo "  [i] Password already set in config file"
             return
         else
@@ -97,6 +174,34 @@ setup_web_password() {
     else
         echo "  [i] Assigning password defined by Environment Variable"
     fi
+}
+
+start_ftl() {
+
+    echo "  [i] pihole-FTL pre-start checks"
+    echo ""
+
+    # Remove possible leftovers from previous pihole-FTL processes
+    rm -f /dev/shm/FTL-* 2>/dev/null
+    rm -f /run/pihole/FTL.sock
+
+    # Is /var/run/pihole used anymore? Or is this just a hangover from old container version
+    # /var/log sorted by running pihole-FTL-prestart.sh
+    # mkdir -p /var/run/pihole /var/log/pihole
+    # touch /var/log/pihole/FTL.log /var/log/pihole/pihole.log
+    # chown -R pihole:pihole /var/run/pihole /var/log/pihole /etc/pihole
+
+    fix_capabilities
+    sh /opt/pihole/pihole-FTL-prestart.sh
+
+    echo "  [i] Starting pihole-FTL ($FTL_CMD) as ${DNSMASQ_USER}"
+    capsh --user=$DNSMASQ_USER --keep=1 -- -c "/usr/bin/pihole-FTL $FTL_CMD >/dev/null" &
+    echo ""
+
+    # Notes on above:
+    # - DNSMASQ_USER default of pihole is in Dockerfile & can be overwritten by runtime container env
+    # - /var/log/pihole/pihole*.log has FTL's output that no-daemon would normally print in FG too
+    #   prevent duplicating it in docker logs by sending to dev null
 }
 
 fix_capabilities() {


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

So far in development of the v6 container, I've not actually tested any v5->v6 migrations, and rather naively assumed that FTL handled everything we needed to worry about.

In https://github.com/pi-hole/pi-hole/issues/5635, we see that this can cause some issues with `setupVars` not being correctly migrated by pihole-FTL due to the way we have _effectively_ been bulldozering over that process.

This PR adds a check right at the beginning of the startup to determine if we are v5 (Simple check, `if setupVars exists and pihole.toml does not`), if we are, then we defer some of the functionality that would write to `pihole.toml` until _after_ FTL has first started... giving it a chance to complete it's migrations

<details>
<summary>Output after first start when upgrading from v5</summary>

```
pihole  |   [i] v5 files detected that have not yet been migrated to v6
pihole  |   [i] Deferring additional configuration until after FTL has started
pihole  |   [i] Note: It is normal to see "Config file /etc/pihole/pihole.toml not available (r): No such file or directory" in the logs at this point
pihole  | 
pihole  |   [i] Setting up user & group for the pihole user
pihole  |   [i] Changing ID for user: pihole (100 => 1000)
pihole  |   [i] Changing ID for group: pihole (101 => 1000)
pihole  | 
pihole  |   [i] Starting crond for scheduled scripts. Randomizing times for gravity and update checker
pihole  | 
pihole  |   [i] Ensuring logrotate script exists in /etc/pihole
pihole  | 
pihole  |   [i] pihole-FTL pre-start checks
pihole  | 
pihole  |   [i] Setting capabilities on pihole-FTL where possible
pihole  |   [i] Applying the following caps to pihole-FTL:
pihole  |         * CAP_CHOWN
pihole  |         * CAP_NET_BIND_SERVICE
pihole  |         * CAP_NET_RAW
pihole  |         * CAP_NET_ADMIN
pihole  | 
pihole  |   [i] Starting pihole-FTL (no-daemon) as pihole
pihole  | 
pihole  |   [i] Starting deferred  Configuration
pihole  |   [i] Password already set in config file
pihole  | 
pihole  |   [i] Gravity migration checks
pihole  |   [i] No adlist file found, creating one with a default blocklist
pihole  |   [i] Existing gravity database found
pihole  |    Upgrading gravity database from version 15 to 16
pihole  |    Upgrading gravity database from version 16 to 17
pihole  |    Upgrading gravity database from version 17 to 18
pihole  |    Upgrading gravity database from version 18 to 19
pihole  | 
pihole  | Core
pihole  |     Version is 7206569 (Latest: null)
pihole  |     Branch is development-v6
pihole  |     Hash is 7206569b (Latest: 7206569b)
pihole  | Web
pihole  |     Version is ed4961f (Latest: null)
pihole  |     Branch is development-v6
pihole  |     Hash is ed4961f4 (Latest: ed4961f4)
pihole  | FTL
pihole  |     Version is vDev-f40d895 (Latest: null)
pihole  |     Branch is development-v6
pihole  |     Hash is f40d8958 (Latest: f40d8958)
pihole  | 
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: ########## FTL started on 2edb14069677! ##########
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: FTL branch: development-v6
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: FTL version: vDev-f40d895
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: FTL commit: f40d8958
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: FTL date: 2024-08-20 21:30:10 +0200
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: FTL user: pihole
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: Compiled for linux/amd64 (compiled on CI) using cc (Alpine 13.2.1_git20240309) 13.2.1 20240309
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: Config file /etc/pihole/pihole.toml not available (r): No such file or directory
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: Config backup file /etc/pihole/config_backups/pihole.toml.1 not available (r): No such file or directory
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: Config backup file /etc/pihole/config_backups/pihole.toml.2 not available (r): No such file or directory
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: Config backup file /etc/pihole/config_backups/pihole.toml.3 not available (r): No such file or directory
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: Config backup file /etc/pihole/config_backups/pihole.toml.4 not available (r): No such file or directory
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: Config backup file /etc/pihole/config_backups/pihole.toml.5 not available (r): No such file or directory
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: Config backup file /etc/pihole/config_backups/pihole.toml.6 not available (r): No such file or directory
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: Config backup file /etc/pihole/config_backups/pihole.toml.7 not available (r): No such file or directory
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: Config backup file /etc/pihole/config_backups/pihole.toml.8 not available (r): No such file or directory
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: Config backup file /etc/pihole/config_backups/pihole.toml.9 not available (r): No such file or directory
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: Config backup file /etc/pihole/config_backups/pihole.toml.10 not available (r): No such file or directory
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: Config backup file /etc/pihole/config_backups/pihole.toml.11 not available (r): No such file or directory
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: Config backup file /etc/pihole/config_backups/pihole.toml.12 not available (r): No such file or directory
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: Config backup file /etc/pihole/config_backups/pihole.toml.13 not available (r): No such file or directory
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: Config backup file /etc/pihole/config_backups/pihole.toml.14 not available (r): No such file or directory
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: No config file nor backup available, using defaults
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: Reading legacy config files from /etc/pihole/pihole-FTL.conf
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO:    PIDFILE: Empty path is not possible, using default
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO:    SETUPVARSFILE: Empty path is not possible, using default
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO:    GRAVITYDB: Empty path is not possible, using default
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO:    WEBROOT: Empty path is not possible, using default
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO:    WEBHOME: Empty path is not possible, using default
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO:    API_INFO_LOG: Empty path is not possible, using default
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO:    WEBDOMAIN: Empty path is not possible, using default
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: Moving /etc/pihole/pihole-FTL.conf to /etc/pihole/pihole-FTL.conf.bck
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: Migrating config from /etc/pihole/setupVars.conf
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: Moved /etc/pihole/setupVars.conf to /etc/pihole/setupVars.conf.old
pihole  | 2024-08-25 18:41:39.069 BST [45M] INFO: Moving /etc/pihole/custom.list to /etc/pihole/custom.list.bck
pihole  | 2024-08-25 18:41:39.070 BST [45M] INFO: Config initialized with webserver ports 80 (HTTP) and 443 (HTTPS), IPv6 support is enabled
pihole  | 2024-08-25 18:41:39.070 BST [45M] INFO: Wrote config file:
pihole  | 2024-08-25 18:41:39.070 BST [45M] INFO:  - 148 total entries
pihole  | 2024-08-25 18:41:39.070 BST [45M] INFO:  - 142 entries are default
pihole  | 2024-08-25 18:41:39.070 BST [45M] INFO:  - 6 entries are modified
pihole  | 2024-08-25 18:41:39.070 BST [45M] INFO:  - 0 entries are forced through environment
pihole  | 2024-08-25 18:41:39.070 BST [45M] INFO: Config file written to /etc/pihole/pihole.toml
pihole  | 2024-08-25 18:41:39.070 BST [45M] WARNING: Insufficient permissions to set process priority to -10 (CAP_SYS_NICE required), process priority remains at 0
pihole  | 2024-08-25 18:41:39.071 BST [45M] INFO: PID of FTL process: 45
pihole  | 2024-08-25 18:41:39.071 BST [45M] INFO: listening on 0.0.0.0 port 53
pihole  | 2024-08-25 18:41:39.071 BST [45M] INFO: listening on :: port 53
pihole  | 2024-08-25 18:41:39.071 BST [45M] INFO: PID of FTL process: 45
pihole  | 2024-08-25 18:41:39.072 BST [45M] INFO: Database version is 12
pihole  | 2024-08-25 18:41:39.072 BST [45M] INFO: Updating long-term database to version 13
pihole  | 2024-08-25 18:41:39.074 BST [45M] INFO: Updating long-term database to version 14
pihole  | 2024-08-25 18:41:39.076 BST [45M] INFO: Updating long-term database to version 15
pihole  | 2024-08-25 18:41:39.078 BST [45M] INFO: Updating long-term database to version 16
pihole  | 2024-08-25 18:41:39.080 BST [45M] INFO: Updating long-term database to version 17
pihole  | 2024-08-25 18:41:39.082 BST [45M] INFO: Updating long-term database to version 18
pihole  | 2024-08-25 18:41:39.084 BST [45M] INFO: Updating long-term database to version 19
pihole  | 2024-08-25 18:41:39.086 BST [45M] INFO: Database successfully initialized
pihole  | 2024-08-25 18:41:39.089 BST [45M] INFO: Imported 0 queries from the on-disk database (it has 0 rows)
pihole  | 2024-08-25 18:41:39.089 BST [45M] INFO: Parsing queries in database
pihole  | 2024-08-25 18:41:39.089 BST [45M] INFO: Imported 0 queries from the long-term database
pihole  | 2024-08-25 18:41:39.089 BST [45M] INFO:  -> Total DNS queries: 0
pihole  | 2024-08-25 18:41:39.089 BST [45M] INFO:  -> Cached DNS queries: 0
pihole  | 2024-08-25 18:41:39.089 BST [45M] INFO:  -> Forwarded DNS queries: 0
pihole  | 2024-08-25 18:41:39.089 BST [45M] INFO:  -> Blocked DNS queries: 0
pihole  | 2024-08-25 18:41:39.089 BST [45M] INFO:  -> Unknown DNS queries: 0
pihole  | 2024-08-25 18:41:39.089 BST [45M] INFO:  -> Unique domains: 0
pihole  | 2024-08-25 18:41:39.089 BST [45M] INFO:  -> Unique clients: 0
pihole  | 2024-08-25 18:41:39.089 BST [45M] INFO:  -> DNS cache records: 0
pihole  | 2024-08-25 18:41:39.089 BST [45M] INFO:  -> Known forward destinations: 0
pihole  | 2024-08-25 18:41:39.091 BST [45M] WARNING: Insufficient permissions to set system time (CAP_SYS_TIME required), NTP client not available
pihole  | 2024-08-25 18:41:39.091 BST [45/T46] INFO: NTP server listening on 0.0.0.0:123 (IPv4)
pihole  | 2024-08-25 18:41:39.091 BST [45/T47] INFO: NTP server listening on :::123 (IPv6)
pihole  | 2024-08-25 18:41:39.091 BST [45M] INFO: FTL is running as user pihole (UID 1000)
pihole  | 2024-08-25 18:41:39.092 BST [45M] INFO: Created SSL/TLS certificate for pi.hole at /etc/pihole/tls.pem
pihole  | 2024-08-25 18:41:39.092 BST [45M] INFO: Reading certificate from /etc/pihole/tls.pem ...
pihole  | 2024-08-25 18:41:39.093 BST [45M] INFO: Using SSL/TLS certificate file /etc/pihole/tls.pem
pihole  | 2024-08-25 18:41:39.093 BST [45M] INFO: Restored 0 API sessions from the database
pihole  | 2024-08-25 18:41:39.094 BST [45M] INFO: Blocking status is enabled
pihole  | 2024-08-25 18:41:39.192 BST [45/T48] INFO: Compiled 0 allow and 0 deny regex for 0 client in 0.1 msec
```

</details>

<details>
<summary>Subsequent container starts</summary>

```
pihole  |   [i] Setting up user & group for the pihole user
pihole  |   [i] ID for user pihole is already 1000, no need to change
pihole  |   [i] ID for group pihole is already 1000, no need to change
pihole  | 
pihole  |   [i] Password already set in config file
pihole  |   [i] Gravity migration checks
pihole  |   [i] Existing gravity database found
pihole  | 
pihole  |   [i] Starting crond for scheduled scripts. Randomizing times for gravity and update checker
pihole  | 
pihole  |   [i] Ensuring logrotate script exists in /etc/pihole
pihole  | 
pihole  |   [i] pihole-FTL pre-start checks
pihole  | 
pihole  |   [i] Setting capabilities on pihole-FTL where possible
pihole  |   [i] Applying the following caps to pihole-FTL:
pihole  |         * CAP_CHOWN
pihole  |         * CAP_NET_BIND_SERVICE
pihole  |         * CAP_NET_RAW
pihole  |         * CAP_NET_ADMIN
pihole  | 
pihole  |   [i] Starting pihole-FTL (no-daemon) as pihole
pihole  | 
pihole  | Core
pihole  |     Version is 7206569 (Latest: null)
pihole  |     Branch is development-v6
pihole  |     Hash is 7206569b (Latest: 7206569b)
pihole  | Web
pihole  |     Version is ed4961f (Latest: null)
pihole  |     Branch is development-v6
pihole  |     Hash is ed4961f4 (Latest: ed4961f4)
pihole  | FTL
pihole  |     Version is vDev-f40d895 (Latest: null)
pihole  |     Branch is development-v6
pihole  |     Hash is f40d8958 (Latest: f40d8958)
pihole  | 
pihole  | 2024-08-25 18:42:55.556 BST [49M] INFO: ########## FTL started on 2edb14069677! ##########
pihole  | 2024-08-25 18:42:55.556 BST [49M] INFO: FTL branch: development-v6
pihole  | 2024-08-25 18:42:55.556 BST [49M] INFO: FTL version: vDev-f40d895
pihole  | 2024-08-25 18:42:55.556 BST [49M] INFO: FTL commit: f40d8958
pihole  | 2024-08-25 18:42:55.556 BST [49M] INFO: FTL date: 2024-08-20 21:30:10 +0200
pihole  | 2024-08-25 18:42:55.556 BST [49M] INFO: FTL user: pihole
pihole  | 2024-08-25 18:42:55.556 BST [49M] INFO: Compiled for linux/amd64 (compiled on CI) using cc (Alpine 13.2.1_git20240309) 13.2.1 20240309
pihole  | 2024-08-25 18:42:55.557 BST [49M] INFO: Wrote config file:
pihole  | 2024-08-25 18:42:55.557 BST [49M] INFO:  - 148 total entries
pihole  | 2024-08-25 18:42:55.557 BST [49M] INFO:  - 142 entries are default
pihole  | 2024-08-25 18:42:55.557 BST [49M] INFO:  - 6 entries are modified
pihole  | 2024-08-25 18:42:55.557 BST [49M] INFO:  - 0 entries are forced through environment
pihole  | 2024-08-25 18:42:55.558 BST [49M] INFO: Parsed config file /etc/pihole/pihole.toml successfully
pihole  | 2024-08-25 18:42:55.558 BST [49M] WARNING: Insufficient permissions to set process priority to -10 (CAP_SYS_NICE required), process priority remains at 0
pihole  | 2024-08-25 18:42:55.558 BST [49M] INFO: PID of FTL process: 49
pihole  | 2024-08-25 18:42:55.558 BST [49M] INFO: listening on 0.0.0.0 port 53
pihole  | 2024-08-25 18:42:55.558 BST [49M] INFO: listening on :: port 53
pihole  | 2024-08-25 18:42:55.559 BST [49M] INFO: PID of FTL process: 49
pihole  | 2024-08-25 18:42:55.559 BST [49M] INFO: Database version is 19
pihole  | 2024-08-25 18:42:55.559 BST [49M] INFO: Database successfully initialized
pihole  | 2024-08-25 18:42:55.560 BST [49M] INFO: Imported 0 queries from the on-disk database (it has 0 rows)
pihole  | 2024-08-25 18:42:55.560 BST [49M] INFO: Parsing queries in database
pihole  | 2024-08-25 18:42:55.560 BST [49M] INFO: Imported 0 queries from the long-term database
pihole  | 2024-08-25 18:42:55.560 BST [49M] INFO:  -> Total DNS queries: 0
pihole  | 2024-08-25 18:42:55.560 BST [49M] INFO:  -> Cached DNS queries: 0
pihole  | 2024-08-25 18:42:55.560 BST [49M] INFO:  -> Forwarded DNS queries: 0
pihole  | 2024-08-25 18:42:55.560 BST [49M] INFO:  -> Blocked DNS queries: 0
pihole  | 2024-08-25 18:42:55.560 BST [49M] INFO:  -> Unknown DNS queries: 0
pihole  | 2024-08-25 18:42:55.560 BST [49M] INFO:  -> Unique domains: 0
pihole  | 2024-08-25 18:42:55.560 BST [49M] INFO:  -> Unique clients: 0
pihole  | 2024-08-25 18:42:55.560 BST [49M] INFO:  -> DNS cache records: 0
pihole  | 2024-08-25 18:42:55.560 BST [49M] INFO:  -> Known forward destinations: 0
pihole  | 2024-08-25 18:42:55.562 BST [49M] WARNING: Insufficient permissions to set system time (CAP_SYS_TIME required), NTP client not available
pihole  | 2024-08-25 18:42:55.562 BST [49/T50] INFO: NTP server listening on 0.0.0.0:123 (IPv4)
pihole  | 2024-08-25 18:42:55.562 BST [49/T51] INFO: NTP server listening on :::123 (IPv6)
pihole  | 2024-08-25 18:42:55.562 BST [49M] INFO: FTL is running as user pihole (UID 1000)
pihole  | 2024-08-25 18:42:55.563 BST [49M] INFO: Reading certificate from /etc/pihole/tls.pem ...
pihole  | 2024-08-25 18:42:55.563 BST [49M] INFO: Using SSL/TLS certificate file /etc/pihole/tls.pem
pihole  | 2024-08-25 18:42:55.563 BST [49M] INFO: Restored 0 API sessions from the database
pihole  | 2024-08-25 18:42:55.564 BST [49M] INFO: Blocking status is enabled
pihole  | 2024-08-25 18:42:55.663 BST [49/T52] INFO: Compiled 0 allow and 0 deny regex for 0 client in 0.1 msec
```

</details>

<details>
<summary>Startup on fresh V6 container (no volumes/empty volumes)</summary>

```
pihole  |   [i] Setting up user & group for the pihole user
pihole  |   [i] Changing ID for user: pihole (100 => 1000)
pihole  |   [i] Changing ID for group: pihole (101 => 1000)
pihole  | 
pihole  |   [i] No DNS upstream set in environment or config file, defaulting to Google DNS
pihole  |   [i] No password set in environment or config file, assigning random password: pfNpEMZb
pihole  |   [i] Gravity migration checks
pihole  |   [i] No adlist file found, creating one with a default blocklist
pihole  |   [i] /etc/pihole/gravity.db does not exist (Likely due to a fresh volume). This is a required file for Pi-hole to operate.
pihole  |   [i] Gravity will now be run to create the database
pihole  |   [i] Creating new gravity database
pihole  |   [i] Upgrading gravity database from version 18 to 19
pihole  |   [i] Migrating content of /etc/pihole/adlists.list into new database
pihole  |   [i] Neutrino emissions detected...
  [✓] Pulling blocklist source list into range
pihole  | 
  [✓] Preparing new gravity database
  [✓] Creating new gravity databases
pihole  |   [i] Using libz compression
pihole  | 
pihole  |   [i] Target: https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
  [✓] Status: Retrieval successful
  [✓] Parsed 170229 exact domains and 0 ABP-style domains (blocking, ignored 0 non-domain entries)
pihole  | 
  [✓] Building tree
pihole  |   [i] Number of gravity domains: 170229 (170229 unique domains)
pihole  |   [i] Number of exact denied domains: 0
pihole  |   [i] Number of regex denied filters: 0
pihole  |   [i] Number of exact allowed domains: 0
pihole  |   [i] Number of regex allowed filters: 0
  [✓] Swapping databases
pihole  |   [✓] The old database remains available
  [✓] Cleaning up stray matter
pihole  | 
pihole  |   [✓] Done.
pihole  | 
pihole  |   [i] Starting crond for scheduled scripts. Randomizing times for gravity and update checker
pihole  | 
pihole  |   [i] Ensuring logrotate script exists in /etc/pihole
pihole  | 
pihole  |   [i] pihole-FTL pre-start checks
pihole  | 
pihole  |   [i] Setting capabilities on pihole-FTL where possible
pihole  |   [i] Applying the following caps to pihole-FTL:
pihole  |         * CAP_CHOWN
pihole  |         * CAP_NET_BIND_SERVICE
pihole  |         * CAP_NET_RAW
pihole  |         * CAP_NET_ADMIN
pihole  | 
pihole  |   [i] Starting pihole-FTL (no-daemon) as pihole
pihole  | 
pihole  | Core
pihole  |     Version is 7206569 (Latest: null)
pihole  |     Branch is development-v6
pihole  |     Hash is 7206569b (Latest: 7206569b)
pihole  | Web
pihole  |     Version is ed4961f (Latest: null)
pihole  |     Branch is development-v6
pihole  |     Hash is ed4961f4 (Latest: ed4961f4)
pihole  | FTL
pihole  |     Version is vDev-f40d895 (Latest: null)
pihole  |     Branch is development-v6
pihole  |     Hash is f40d8958 (Latest: f40d8958)
pihole  | 
pihole  | 2024-08-25 18:43:54.568 BST [159M] INFO: ########## FTL started on 02194a61b051! ##########
pihole  | 2024-08-25 18:43:54.568 BST [159M] INFO: FTL branch: development-v6
pihole  | 2024-08-25 18:43:54.568 BST [159M] INFO: FTL version: vDev-f40d895
pihole  | 2024-08-25 18:43:54.568 BST [159M] INFO: FTL commit: f40d8958
pihole  | 2024-08-25 18:43:54.568 BST [159M] INFO: FTL date: 2024-08-20 21:30:10 +0200
pihole  | 2024-08-25 18:43:54.568 BST [159M] INFO: FTL user: pihole
pihole  | 2024-08-25 18:43:54.568 BST [159M] INFO: Compiled for linux/amd64 (compiled on CI) using cc (Alpine 13.2.1_git20240309) 13.2.1 20240309
pihole  | 2024-08-25 18:43:54.569 BST [159M] INFO: Wrote config file:
pihole  | 2024-08-25 18:43:54.569 BST [159M] INFO:  - 148 total entries
pihole  | 2024-08-25 18:43:54.569 BST [159M] INFO:  - 145 entries are default
pihole  | 2024-08-25 18:43:54.569 BST [159M] INFO:  - 3 entries are modified
pihole  | 2024-08-25 18:43:54.569 BST [159M] INFO:  - 0 entries are forced through environment
pihole  | 2024-08-25 18:43:54.569 BST [159M] INFO: Parsed config file /etc/pihole/pihole.toml successfully
pihole  | 2024-08-25 18:43:54.570 BST [159M] WARNING: Insufficient permissions to set process priority to -10 (CAP_SYS_NICE required), process priority remains at 0
pihole  | 2024-08-25 18:43:54.570 BST [159M] INFO: PID of FTL process: 159
pihole  | 2024-08-25 18:43:54.570 BST [159M] INFO: listening on 0.0.0.0 port 53
pihole  | 2024-08-25 18:43:54.570 BST [159M] INFO: listening on :: port 53
pihole  | 2024-08-25 18:43:54.570 BST [159M] INFO: PID of FTL process: 159
pihole  | 2024-08-25 18:43:54.570 BST [159M] WARNING: No database file found, creating new (empty) database
pihole  | 2024-08-25 18:43:54.580 BST [159M] INFO: Database version is 1
pihole  | 2024-08-25 18:43:54.580 BST [159M] INFO: Updating long-term database to version 2
pihole  | 2024-08-25 18:43:54.582 BST [159M] INFO: Updating long-term database to version 3
pihole  | 2024-08-25 18:43:54.584 BST [159M] INFO: Updating long-term database to version 4
pihole  | 2024-08-25 18:43:54.585 BST [159M] INFO: Updating long-term database to version 5
pihole  | 2024-08-25 18:43:54.587 BST [159M] INFO: Updating long-term database to version 6
pihole  | 2024-08-25 18:43:54.589 BST [159M] INFO: Updating long-term database to version 7
pihole  | 2024-08-25 18:43:54.590 BST [159M] INFO: Updating long-term database to version 8
pihole  | 2024-08-25 18:43:54.593 BST [159M] INFO: Updating long-term database to version 9
pihole  | 2024-08-25 18:43:54.594 BST [159M] INFO: Updating long-term database to version 10
pihole  | 2024-08-25 18:43:54.597 BST [159M] INFO: Updating long-term database to version 11
pihole  | 2024-08-25 18:43:54.599 BST [159M] INFO: Updating long-term database to version 12
pihole  | 2024-08-25 18:43:54.601 BST [159M] INFO: Updating long-term database to version 13
pihole  | 2024-08-25 18:43:54.602 BST [159M] INFO: Updating long-term database to version 14
pihole  | 2024-08-25 18:43:54.603 BST [159M] INFO: Updating long-term database to version 15
pihole  | 2024-08-25 18:43:54.606 BST [159M] INFO: Updating long-term database to version 16
pihole  | 2024-08-25 18:43:54.607 BST [159M] INFO: Updating long-term database to version 17
pihole  | 2024-08-25 18:43:54.609 BST [159M] INFO: Updating long-term database to version 18
pihole  | 2024-08-25 18:43:54.611 BST [159M] INFO: Updating long-term database to version 19
pihole  | 2024-08-25 18:43:54.612 BST [159M] INFO: Database successfully initialized
pihole  | 2024-08-25 18:43:54.615 BST [159M] INFO: Imported 0 queries from the on-disk database (it has 0 rows)
pihole  | 2024-08-25 18:43:54.615 BST [159M] INFO: Parsing queries in database
pihole  | 2024-08-25 18:43:54.615 BST [159M] INFO: Imported 0 queries from the long-term database
pihole  | 2024-08-25 18:43:54.615 BST [159M] INFO:  -> Total DNS queries: 0
pihole  | 2024-08-25 18:43:54.615 BST [159M] INFO:  -> Cached DNS queries: 0
pihole  | 2024-08-25 18:43:54.615 BST [159M] INFO:  -> Forwarded DNS queries: 0
pihole  | 2024-08-25 18:43:54.615 BST [159M] INFO:  -> Blocked DNS queries: 0
pihole  | 2024-08-25 18:43:54.615 BST [159M] INFO:  -> Unknown DNS queries: 0
pihole  | 2024-08-25 18:43:54.615 BST [159M] INFO:  -> Unique domains: 0
pihole  | 2024-08-25 18:43:54.615 BST [159M] INFO:  -> Unique clients: 0
pihole  | 2024-08-25 18:43:54.615 BST [159M] INFO:  -> DNS cache records: 0
pihole  | 2024-08-25 18:43:54.615 BST [159M] INFO:  -> Known forward destinations: 0
pihole  | 2024-08-25 18:43:54.617 BST [159M] WARNING: Insufficient permissions to set system time (CAP_SYS_TIME required), NTP client not available
pihole  | 2024-08-25 18:43:54.617 BST [159/T160] INFO: NTP server listening on 0.0.0.0:123 (IPv4)
pihole  | 2024-08-25 18:43:54.617 BST [159/T161] INFO: NTP server listening on :::123 (IPv6)
pihole  | 2024-08-25 18:43:54.617 BST [159M] INFO: FTL is running as user pihole (UID 1000)
pihole  | 2024-08-25 18:43:54.618 BST [159M] INFO: Created SSL/TLS certificate for pi.hole at /etc/pihole/tls.pem
pihole  | 2024-08-25 18:43:54.618 BST [159M] INFO: Reading certificate from /etc/pihole/tls.pem ...
pihole  | 2024-08-25 18:43:54.618 BST [159M] INFO: Using SSL/TLS certificate file /etc/pihole/tls.pem
pihole  | 2024-08-25 18:43:54.619 BST [159M] INFO: Restored 0 API sessions from the database
pihole  | 2024-08-25 18:43:54.620 BST [159M] INFO: Blocking status is enabled
pihole  | 2024-08-25 18:43:54.717 BST [159/T162] INFO: Compiled 0 allow and 0 deny regex for 0 client in 0.0 msec
```

</details>

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_