### PR TITLE
Migrate old Pi-hole owned dnsmasq config files into /etc/pihole/migration_backup_v6

### DIFF
--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -147,6 +147,29 @@ ftl_config() {
     setup_web_password
 }
 
+migrate_dnsmasq_d_contents() {
+    # Previously, Pi-hole created a number of files in /etc/dnsmasq.d
+    # During migration, their content is copied into the new single source of
+    # truth file /etc/pihole/pihole.toml and the old files are moved away to
+    # avoid conflicts with other services on this system
+    echo "  [i] Migrating dnsmasq configuration files"
+    V6_CONF_MIGRATION_DIR="/etc/pihole/migration_backup_v6"
+    # Create target directory and make it owned by pihole:pihole
+    mkdir -p "${V6_CONF_MIGRATION_DIR}"
+    chown pihole:pihole "${V6_CONF_MIGRATION_DIR}"
+
+    # Move all conf files originally created by Pi-hole into this directory
+    # - 01-pihole.conf
+    # - 02-pihole-dhcp.conf
+    # - 04-pihole-static-dhcp.conf
+    # - 05-pihole-custom-cname.conf
+    # - 06-rfc6761.conf
+
+    mv /etc/dnsmasq.d/0{1,2,4,5}-pihole*.conf "${V6_CONF_MIGRATION_DIR}/" 2>/dev/null || true
+    mv /etc/dnsmasq.d/06-rfc6761.conf "${V6_CONF_MIGRATION_DIR}/" 2>/dev/null || true
+    echo ""
+}
+
 setup_web_password() {
     # If FTLCONF_webserver_api_password is not set
     if [ -z "${FTLCONF_webserver_api_password+x}" ]; then


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

This step from the bare metal install script has been missed so far in Docker, we simply run it on the first check if we detect that it is a v5->v6 upgrade

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_