### PR TITLE
Confirm validity of downloaded FTL binary when building

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,8 @@ usage() {
 }
 
 # Set default values
-DOCKER_BUILD_CMD="docker buildx build src/. --tag pihole:local --load --no-cache"
+TAG="pihole:local"
+DOCKER_BUILD_CMD="docker buildx build src/. --tag ${TAG} --load --no-cache"
 FTL_FLAG=false
 
 # Parse command line arguments
@@ -69,8 +70,9 @@ while [[ $# -gt 0 ]]; do
         shift
         ;;
     -t | --tag)
-        TAG="$2"
-        DOCKER_BUILD_CMD=${DOCKER_BUILD_CMD/pihole:local/$TAG}
+        CUSTOM_TAG="$2"
+        DOCKER_BUILD_CMD=${DOCKER_BUILD_CMD/$TAG/$CUSTOM_TAG}
+        TAG=$CUSTOM_TAG
         shift
         shift
         ;;
@@ -88,3 +90,16 @@ done
 # Execute the docker build command
 echo "Executing command: $DOCKER_BUILD_CMD"
 eval $DOCKER_BUILD_CMD
+
+# Check exit code of previous command
+if [ $? -ne 0 ]; then
+    echo ""
+    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+    echo "!! ERROR: Docker build failed, please review logs above !!"
+    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+    exit 1
+else
+    echo ""
+    echo "Successfully built Docker image with tag '$TAG'"
+    docker images $TAG
+fi

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -83,11 +83,12 @@ RUN if   [ "$TARGETPLATFORM" = "linux/amd64" ];    then FTLARCH=amd64; \
     && echo "Arch: ${TARGETPLATFORM}, FTLARCH: ${FTLARCH}" \
     && curl -sSL "https://ftl.pi-hole.net/${FTL_BRANCH}/pihole-FTL-${FTLARCH}" -o /usr/bin/pihole-FTL \
     && chmod +x /usr/bin/pihole-FTL \
-    && readelf -h /usr/bin/pihole-FTL || cat /usr/bin/pihole-FTL
+    && readelf -h /usr/bin/pihole-FTL || (echo "Error with downloaded FTL binary" && exit 1)
 
 FROM base AS local-ftl-install
 # pihole-FTL must be built from source and copied to the src directory first!
 COPY --chmod=0755 pihole-FTL /usr/bin/pihole-FTL
+RUN  readelf -h /usr/bin/pihole-FTL || (echo "Error with local FTL binary" && exit 1)
 
 # Use the appropriate FTL Install stage based on the FTL_SOURCE build-arg
 FROM ${FTL_SOURCE}-ftl-install AS final


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Addresses comment by @DL6ER here https://github.com/pi-hole/FTL/issues/2035#issuecomment-2343879765

The Dockerfile had a `readelf` command to check the downloaded binary was a binary, but really we should be hard existing if it is invalid.

Adds some additional output to the `build.sh` to inform the user that something went wrong, or indeed that everything is OK.

<details>
<summary>Successful build</summary>

```
adam@adam-pc:~/repos/docker-pi-hole$ ./build.sh
Executing command: docker buildx build src/. --tag pihole:local --load --no-cache
[+] Building 5.3s (19/19) FINISHED                                                                                                                                                 docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                         0.0s
 => => transferring dockerfile: 4.09kB                                                                                                                                                       0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:1                                                                                                                    0.6s
 => CACHED docker-image://docker.io/docker/dockerfile:1@sha256:865e5dd094beca432e8c0a1d5e1c465db5f998dca4e439981029b3b81fb39ed5                                                              0.0s
 => [internal] load metadata for docker.io/library/alpine:3.20                                                                                                                               0.5s
 => [internal] load .dockerignore                                                                                                                                                            0.0s
 => => transferring context: 82B                                                                                                                                                             0.0s
 => CACHED [base 1/9] FROM docker.io/library/alpine:3.20@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d                                                             0.0s
 => CACHED [base 3/9] ADD https://ftl.pi-hole.net/macvendor.db /macvendor.db                                                                                                                 0.0s
 => [internal] load build context                                                                                                                                                            0.0s
 => => transferring context: 98B                                                                                                                                                             0.0s
 => CACHED [base 5/9] ADD --chmod=0755 https://raw.githubusercontent.com/pi-hole/PADD/development/padd.sh /usr/local/bin/padd                                                                0.0s
 => [base 2/9] RUN apk add --no-cache     bash     bind-tools     binutils     coreutils     curl     git     grep     iproute2-ss     jq     libcap     logrotate     ncurses     nmap-nca  1.2s
 => [base 3/9] ADD https://ftl.pi-hole.net/macvendor.db /macvendor.db                                                                                                                        0.0s
 => [base 4/9] COPY crontab.txt /crontab.txt                                                                                                                                                 0.0s
 => [base 5/9] ADD --chmod=0755 https://raw.githubusercontent.com/pi-hole/PADD/development/padd.sh /usr/local/bin/padd                                                                       0.0s
 => [base 6/9] RUN git clone --depth 1 --single-branch --branch development https://github.com/pi-hole/web.git /var/www/html/admin &&     git clone --depth 1 --single-branch --branch deve  1.3s
 => [base 7/9] RUN cd /etc/.pihole &&     install -Dm755 -d /opt/pihole &&     install -Dm755 -t /opt/pihole gravity.sh &&     install -Dm755 -t /opt/pihole ./advanced/Scripts/*.sh &&      0.4s 
 => [base 8/9] COPY --chmod=0755 bash_functions.sh /usr/bin/bash_functions.sh                                                                                                                0.0s 
 => [base 9/9] COPY --chmod=0755 start.sh /usr/bin/start.sh                                                                                                                                  0.0s
 => [remote-ftl-install 1/1] RUN if   [ "linux/amd64" = "linux/amd64" ];    then FTLARCH=amd64;     elif [ "linux/amd64" = "linux/386" ];      then FTLARCH=386;     elif [ "linux/amd64" =  0.9s
 => exporting to image                                                                                                                                                                       0.2s
 => => exporting layers                                                                                                                                                                      0.2s
 => => writing image sha256:9c94987e2ed941acf41e9d14cc7c8b540861ca8ef17c71de5afb695c145c18f8                                                                                                 0.0s 
 => => naming to docker.io/library/pihole:local                                                                                                                                              0.0s 
                                                                                                                                                                                                  
Successfully built Docker image with tag 'pihole:local'                                                                                                                                           
REPOSITORY   TAG       IMAGE ID       CREATED                  SIZE
pihole       local     9c94987e2ed9   Less than a second ago   89.9MB
```

</details>

<details>
<summary>Unsuccessful build</summary>

```
adam@adam-pc:~/repos/docker-pi-hole$ ./build.sh -f non-existant-ftl-branch
Executing command: docker buildx build src/. --tag pihole:local --load --no-cache --build-arg FTL_BRANCH=non-existant-ftl-branch
[+] Building 4.4s (18/18) FINISHED                                                                                                                                                 docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                         0.0s
 => => transferring dockerfile: 4.09kB                                                                                                                                                       0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:1                                                                                                                    0.4s
 => CACHED docker-image://docker.io/docker/dockerfile:1@sha256:865e5dd094beca432e8c0a1d5e1c465db5f998dca4e439981029b3b81fb39ed5                                                              0.0s
 => [internal] load metadata for docker.io/library/alpine:3.20                                                                                                                               0.3s
 => [internal] load .dockerignore                                                                                                                                                            0.0s
 => => transferring context: 82B                                                                                                                                                             0.0s
 => CACHED [base 1/9] FROM docker.io/library/alpine:3.20@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d                                                             0.0s
 => CACHED [base 3/9] ADD https://ftl.pi-hole.net/macvendor.db /macvendor.db                                                                                                                 0.0s
 => [internal] load build context                                                                                                                                                            0.0s
 => => transferring context: 98B                                                                                                                                                             0.0s
 => CACHED [base 5/9] ADD --chmod=0755 https://raw.githubusercontent.com/pi-hole/PADD/development/padd.sh /usr/local/bin/padd                                                                0.0s
 => [base 2/9] RUN apk add --no-cache     bash     bind-tools     binutils     coreutils     curl     git     grep     iproute2-ss     jq     libcap     logrotate     ncurses     nmap-nca  1.2s
 => [base 3/9] ADD https://ftl.pi-hole.net/macvendor.db /macvendor.db                                                                                                                        0.0s 
 => [base 4/9] COPY crontab.txt /crontab.txt                                                                                                                                                 0.0s 
 => [base 5/9] ADD --chmod=0755 https://raw.githubusercontent.com/pi-hole/PADD/development/padd.sh /usr/local/bin/padd                                                                       0.0s 
 => [base 6/9] RUN git clone --depth 1 --single-branch --branch development https://github.com/pi-hole/web.git /var/www/html/admin &&     git clone --depth 1 --single-branch --branch deve  1.3s 
 => [base 7/9] RUN cd /etc/.pihole &&     install -Dm755 -d /opt/pihole &&     install -Dm755 -t /opt/pihole gravity.sh &&     install -Dm755 -t /opt/pihole ./advanced/Scripts/*.sh &&      0.4s 
 => [base 8/9] COPY --chmod=0755 bash_functions.sh /usr/bin/bash_functions.sh                                                                                                                0.0s 
 => [base 9/9] COPY --chmod=0755 start.sh /usr/bin/start.sh                                                                                                                                  0.0s
 => ERROR [remote-ftl-install 1/1] RUN if   [ "linux/amd64" = "linux/amd64" ];    then FTLARCH=amd64;     elif [ "linux/amd64" = "linux/386" ];      then FTLARCH=386;     elif [ "linux/am  0.6s
------                                                                                                                                                                                            
 > [remote-ftl-install 1/1] RUN if   [ "linux/amd64" = "linux/amd64" ];    then FTLARCH=amd64;     elif [ "linux/amd64" = "linux/386" ];      then FTLARCH=386;     elif [ "linux/amd64" = "linux/arm/v6" ];   then FTLARCH=armv6;     elif [ "linux/amd64" = "linux/arm/v7" ];   then FTLARCH=armv7;     elif [ "linux/amd64" = "linux/arm64" ];    then FTLARCH=arm64;     elif [ "linux/amd64" = "linux/riscv64" ];  then FTLARCH=riscv64;     else FTLARCH=amd64; fi     && echo "Arch: linux/amd64, FTLARCH: ${FTLARCH}"     && curl -sSL "https://ftl.pi-hole.net/non-existant-ftl-branch/pihole-FTL-${FTLARCH}" -o /usr/bin/pihole-FTL     && chmod +x /usr/bin/pihole-FTL     && readelf -h /usr/bin/pihole-FTL || (cat /usr/bin/pihole-FTL && echo "Error with downloaded FTL binary" && exit 1):
0.525 Arch: linux/amd64, FTLARCH: amd64
0.544 readelf: Error: Not an ELF file - it has the wrong magic bytes at the start
0.545 <html>
0.545 <head><title>404 Not Found</title></head>
0.545 <body>
0.545 <center><h1>404 Not Found</h1></center>
0.545 <hr><center>nginx/1.25.0</center>
0.545 </body>
0.545 </html>
0.545 Error with downloaded FTL binary
------
Dockerfile:75
--------------------
  74 |     # Download the latest version of pihole-FTL for the correct architecture
  75 | >>> RUN if   [ "$TARGETPLATFORM" = "linux/amd64" ];    then FTLARCH=amd64; \
  76 | >>>     elif [ "$TARGETPLATFORM" = "linux/386" ];      then FTLARCH=386; \
  77 | >>>     elif [ "$TARGETPLATFORM" = "linux/arm/v6" ];   then FTLARCH=armv6; \
  78 | >>>     elif [ "$TARGETPLATFORM" = "linux/arm/v7" ];   then FTLARCH=armv7; \
  79 | >>>     # Note for the future, "linux/arm6/v8" is not a valid value for TARGETPLATFORM, despite the CI platform name being that.
  80 | >>>     elif [ "$TARGETPLATFORM" = "linux/arm64" ];    then FTLARCH=arm64; \
  81 | >>>     elif [ "$TARGETPLATFORM" = "linux/riscv64" ];  then FTLARCH=riscv64; \
  82 | >>>     else FTLARCH=amd64; fi \
  83 | >>>     && echo "Arch: ${TARGETPLATFORM}, FTLARCH: ${FTLARCH}" \
  84 | >>>     && curl -sSL "https://ftl.pi-hole.net/${FTL_BRANCH}/pihole-FTL-${FTLARCH}" -o /usr/bin/pihole-FTL \
  85 | >>>     && chmod +x /usr/bin/pihole-FTL \
  86 | >>>     && readelf -h /usr/bin/pihole-FTL || (cat /usr/bin/pihole-FTL && echo "Error with downloaded FTL binary" && exit 1)
  87 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c if   [ \"$TARGETPLATFORM\" = \"linux/amd64\" ];    then FTLARCH=amd64;     elif [ \"$TARGETPLATFORM\" = \"linux/386\" ];      then FTLARCH=386;     elif [ \"$TARGETPLATFORM\" = \"linux/arm/v6\" ];   then FTLARCH=armv6;     elif [ \"$TARGETPLATFORM\" = \"linux/arm/v7\" ];   then FTLARCH=armv7;     elif [ \"$TARGETPLATFORM\" = \"linux/arm64\" ];    then FTLARCH=arm64;     elif [ \"$TARGETPLATFORM\" = \"linux/riscv64\" ];  then FTLARCH=riscv64;     else FTLARCH=amd64; fi     && echo \"Arch: ${TARGETPLATFORM}, FTLARCH: ${FTLARCH}\"     && curl -sSL \"https://ftl.pi-hole.net/${FTL_BRANCH}/pihole-FTL-${FTLARCH}\" -o /usr/bin/pihole-FTL     && chmod +x /usr/bin/pihole-FTL     && readelf -h /usr/bin/pihole-FTL || (cat /usr/bin/pihole-FTL && echo \"Error with downloaded FTL binary\" && exit 1)" did not complete successfully: exit code: 1

!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!! ERROR: Docker build failed, please review logs above !!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```


</details>



---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_