### PR TITLE
Always terminate the container if pihole-FTL binary exits

### DIFF
--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -199,34 +199,6 @@ setup_web_password() {
     fi
 }
 
-start_ftl() {
-
-    echo "  [i] pihole-FTL pre-start checks"
-
-    # Remove possible leftovers from previous pihole-FTL processes
-    rm -f /dev/shm/FTL-* 2>/dev/null
-    rm -f /run/pihole/FTL.sock
-
-    fix_capabilities
-    sh /opt/pihole/pihole-FTL-prestart.sh
-
-    echo "  [i] Starting pihole-FTL ($FTL_CMD) as ${DNSMASQ_USER}"
-    echo ""
-
-    capsh --user=$DNSMASQ_USER --keep=1 -- -c "/usr/bin/pihole-FTL $FTL_CMD >/dev/null"
-    ftl_exit_code=$?
-    # Store the exit code so that we can exit the container with the same code from start.sh
-    echo $ftl_exit_code >/pihole-FTL.exit
-
-    # pihole-FTL has exited, so we should stop the rest of the container
-    killall --signal 15 start.sh
-
-    # Notes on above:
-    # - DNSMASQ_USER default of pihole is in Dockerfile & can be overwritten by runtime container env
-    # - /var/log/pihole/pihole*.log has FTL's output that no-daemon would normally print in FG too
-    #   prevent duplicating it in docker logs by sending to dev null
-}
-
 fix_capabilities() {
     # Testing on Docker 20.10.14 with no caps set shows the following caps available to the container:
     # Current: cap_chown,cap_dac_override,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,cap_net_bind_service,cap_net_raw,cap_sys_chroot,cap_mknod,cap_audit_write,cap_setfcap=ep

--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -202,24 +202,24 @@ setup_web_password() {
 start_ftl() {
 
     echo "  [i] pihole-FTL pre-start checks"
-    echo ""
 
     # Remove possible leftovers from previous pihole-FTL processes
     rm -f /dev/shm/FTL-* 2>/dev/null
     rm -f /run/pihole/FTL.sock
 
-    # Is /var/run/pihole used anymore? Or is this just a hangover from old container version
-    # /var/log sorted by running pihole-FTL-prestart.sh
-    # mkdir -p /var/run/pihole /var/log/pihole
-    # touch /var/log/pihole/FTL.log /var/log/pihole/pihole.log
-    # chown -R pihole:pihole /var/run/pihole /var/log/pihole /etc/pihole
-
     fix_capabilities
     sh /opt/pihole/pihole-FTL-prestart.sh
 
     echo "  [i] Starting pihole-FTL ($FTL_CMD) as ${DNSMASQ_USER}"
-    capsh --user=$DNSMASQ_USER --keep=1 -- -c "/usr/bin/pihole-FTL $FTL_CMD >/dev/null" &
     echo ""
+
+    capsh --user=$DNSMASQ_USER --keep=1 -- -c "/usr/bin/pihole-FTL $FTL_CMD >/dev/null"
+    ftl_exit_code=$?
+    # Store the exit code so that we can exit the container with the same code from start.sh
+    echo $ftl_exit_code >/pihole-FTL.exit
+
+    # pihole-FTL has exited, so we should stop the rest of the container
+    killall --signal 15 start.sh
 
     # Notes on above:
     # - DNSMASQ_USER default of pihole is in Dockerfile & can be overwritten by runtime container env

--- a/src/start.sh
+++ b/src/start.sh
@@ -145,8 +145,8 @@ stop() {
   echo "      https://docs.docker.com/engine/containers/start-containers-automatically/#use-a-restart-policy"
   echo ""
 
-  # # If we are running pytest, keep the container alive for a little longer
-  # # to allow the tests to complete
+  # If we are running pytest, keep the container alive for a little longer
+  # to allow the tests to complete
   if [[ ${PYTEST} ]]; then
     sleep 10
   fi


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Inspired by a conversation with @DL6ER - currently if pihole-FTL crashes, the container just sits there doing nothing - users are unable to do anything with it.

This PR addresses the issue by ensure that the container is always terminated in case of `pihole-FTL` being terminated. We also store the exit code of FTL, so that we can exit the container with the same code (useful in case of `on-failure[:max-retries]` restart policy)

<details>
<summary>`docker stop pihole`</summary>

```
pihole  | 2024-10-06 22:41:12.532 BST [56M] INFO: ########## FTL started on 6ccaf1acbf31! ##########
pihole  | 2024-10-06 22:41:12.532 BST [56M] INFO: FTL branch: development
pihole  | 2024-10-06 22:41:12.532 BST [56M] INFO: FTL version: vDev-e558f79
pihole  | 2024-10-06 22:41:12.532 BST [56M] INFO: FTL commit: e558f798
pihole  | 2024-10-06 22:41:12.532 BST [56M] INFO: FTL date: 2024-10-05 18:06:26 +0200
pihole  | 2024-10-06 22:41:12.532 BST [56M] INFO: FTL user: pihole
pihole  | 2024-10-06 22:41:12.532 BST [56M] INFO: Compiled for linux/amd64 (compiled on CI) using cc (Alpine 13.2.1_git20240309) 13.2.1 20240309
pihole  | 2024-10-06 22:41:12.533 BST [56M] INFO: Wrote config file:
pihole  | 2024-10-06 22:41:12.533 BST [56M] INFO:  - 150 total entries
pihole  | 2024-10-06 22:41:12.533 BST [56M] INFO:  - 147 entries are default
pihole  | 2024-10-06 22:41:12.533 BST [56M] INFO:  - 3 entries are modified
pihole  | 2024-10-06 22:41:12.533 BST [56M] INFO:  - 0 entries are forced through environment
pihole  | 2024-10-06 22:41:12.534 BST [56M] INFO: Parsed config file /etc/pihole/pihole.toml successfully
pihole  | 2024-10-06 22:41:12.534 BST [56M] WARNING: Insufficient permissions to set process priority to -10 (CAP_SYS_NICE required), process priority remains at 0
pihole  | 2024-10-06 22:41:12.535 BST [56M] INFO: PID of FTL process: 56
pihole  | 2024-10-06 22:41:12.535 BST [56M] INFO: listening on 0.0.0.0 port 53
pihole  | 2024-10-06 22:41:12.535 BST [56M] INFO: listening on :: port 53
pihole  | 2024-10-06 22:41:12.535 BST [56M] INFO: PID of FTL process: 56
pihole  | 2024-10-06 22:41:12.536 BST [56M] INFO: Database version is 19
pihole  | 2024-10-06 22:41:12.536 BST [56M] INFO: Database successfully initialized
pihole  | 2024-10-06 22:41:12.537 BST [56M] INFO: Imported 0 queries from the on-disk database (it has 0 rows)
pihole  | 2024-10-06 22:41:12.537 BST [56M] INFO: Parsing queries in database
pihole  | 2024-10-06 22:41:12.537 BST [56M] INFO: Imported 0 queries from the long-term database
pihole  | 2024-10-06 22:41:12.537 BST [56M] INFO:  -> Total DNS queries: 0
pihole  | 2024-10-06 22:41:12.537 BST [56M] INFO:  -> Cached DNS queries: 0
pihole  | 2024-10-06 22:41:12.537 BST [56M] INFO:  -> Forwarded DNS queries: 0
pihole  | 2024-10-06 22:41:12.537 BST [56M] INFO:  -> Blocked DNS queries: 0
pihole  | 2024-10-06 22:41:12.537 BST [56M] INFO:  -> Unknown DNS queries: 0
pihole  | 2024-10-06 22:41:12.537 BST [56M] INFO:  -> Unique domains: 0
pihole  | 2024-10-06 22:41:12.537 BST [56M] INFO:  -> Unique clients: 0
pihole  | 2024-10-06 22:41:12.537 BST [56M] INFO:  -> DNS cache records: 0
pihole  | 2024-10-06 22:41:12.537 BST [56M] INFO:  -> Known forward destinations: 0
pihole  | 2024-10-06 22:41:12.553 BST [56M] WARNING: Insufficient permissions to set system time (CAP_SYS_TIME required), NTP client not available
pihole  | 2024-10-06 22:41:12.553 BST [56/T58] INFO: NTP server listening on :::123 (IPv6)
pihole  | 2024-10-06 22:41:12.553 BST [56/T57] INFO: NTP server listening on 0.0.0.0:123 (IPv4)
pihole  | 2024-10-06 22:41:12.553 BST [56M] INFO: FTL is running as user pihole (UID 1000)
pihole  | 2024-10-06 22:41:12.553 BST [56M] INFO: Reading certificate from /etc/pihole/tls.pem ...
pihole  | 2024-10-06 22:41:12.554 BST [56M] INFO: Using SSL/TLS certificate file /etc/pihole/tls.pem
pihole  | 2024-10-06 22:41:12.554 BST [56M] INFO: Restored 0 API sessions from the database
pihole  | 2024-10-06 22:41:12.555 BST [56M] INFO: Blocking status is enabled
pihole  | 2024-10-06 22:41:12.654 BST [56/T59] INFO: Compiled 0 allow and 0 deny regex for 0 client in 0.0 msec
pihole  | 
pihole  |   [i] Container stop requested...
pihole  |   [i] pihole-FTL is running - Attempting to shut it down cleanly
pihole  | 
pihole  | 2024-10-06 22:41:16.699 BST [56M] INFO: Asked to terminate by "N/A" (PID 171, user root UID 0)
pihole  | 2024-10-06 22:41:16.759 BST [56/T62] INFO: Terminating timer thread
pihole  | 2024-10-06 22:41:16.762 BST [56/T59] INFO: Terminating database thread
pihole  | 2024-10-06 22:41:16.950 BST [56M] INFO: Finished final database update
pihole  | 2024-10-06 22:41:16.950 BST [56M] INFO: Waiting for threads to join
pihole  | 2024-10-06 22:41:16.950 BST [56M] INFO: Thread housekeeper (1) is idle, terminating it.
pihole  | 2024-10-06 22:41:16.950 BST [56M] INFO: Thread dns-client (2) is idle, terminating it.
pihole  | 2024-10-06 22:41:16.950 BST [56M] INFO: All threads joined
pihole  | 2024-10-06 22:41:16.950 BST [56M] INFO: Stored 0 API sessions in the database
pihole  | 2024-10-06 22:41:17.564 BST [56M] INFO: ########## FTL terminated after 5s 31ms  (code 0)! ##########
pihole  | 
pihole  |   [i] pihole-FTL exited with status 0
pihole  | 
pihole  |   [i] Container will now stop or restart depending on your restart policy
pihole  |       https://docs.docker.com/engine/containers/start-containers-automatically/#use-a-restart-policy
pihole  | 
pihole exited with code 0
```

</details>

<details>
<summary>`docker exec -it pihole killall --signal 15 pihole-FTL`</summary>

```
pihole  | 2024-10-06 22:42:42.417 BST [56M] INFO: ########## FTL started on 0d9149f7f785! ##########
pihole  | 2024-10-06 22:42:42.417 BST [56M] INFO: FTL branch: development
pihole  | 2024-10-06 22:42:42.417 BST [56M] INFO: FTL version: vDev-e558f79
pihole  | 2024-10-06 22:42:42.417 BST [56M] INFO: FTL commit: e558f798
pihole  | 2024-10-06 22:42:42.418 BST [56M] INFO: FTL date: 2024-10-05 18:06:26 +0200
pihole  | 2024-10-06 22:42:42.418 BST [56M] INFO: FTL user: pihole
pihole  | 2024-10-06 22:42:42.418 BST [56M] INFO: Compiled for linux/amd64 (compiled on CI) using cc (Alpine 13.2.1_git20240309) 13.2.1 20240309
pihole  | 2024-10-06 22:42:42.418 BST [56M] INFO: Wrote config file:
pihole  | 2024-10-06 22:42:42.418 BST [56M] INFO:  - 150 total entries
pihole  | 2024-10-06 22:42:42.418 BST [56M] INFO:  - 147 entries are default
pihole  | 2024-10-06 22:42:42.418 BST [56M] INFO:  - 3 entries are modified
pihole  | 2024-10-06 22:42:42.418 BST [56M] INFO:  - 0 entries are forced through environment
pihole  | 2024-10-06 22:42:42.419 BST [56M] INFO: Parsed config file /etc/pihole/pihole.toml successfully
pihole  | 2024-10-06 22:42:42.419 BST [56M] WARNING: Insufficient permissions to set process priority to -10 (CAP_SYS_NICE required), process priority remains at 0
pihole  | 2024-10-06 22:42:42.419 BST [56M] INFO: PID of FTL process: 56
pihole  | 2024-10-06 22:42:42.419 BST [56M] INFO: listening on 0.0.0.0 port 53
pihole  | 2024-10-06 22:42:42.419 BST [56M] INFO: listening on :: port 53
pihole  | 2024-10-06 22:42:42.420 BST [56M] INFO: PID of FTL process: 56
pihole  | 2024-10-06 22:42:42.420 BST [56M] INFO: Database version is 19
pihole  | 2024-10-06 22:42:42.420 BST [56M] INFO: Database successfully initialized
pihole  | 2024-10-06 22:42:42.421 BST [56M] INFO: Imported 0 queries from the on-disk database (it has 0 rows)
pihole  | 2024-10-06 22:42:42.421 BST [56M] INFO: Parsing queries in database
pihole  | 2024-10-06 22:42:42.421 BST [56M] INFO: Imported 0 queries from the long-term database
pihole  | 2024-10-06 22:42:42.421 BST [56M] INFO:  -> Total DNS queries: 0
pihole  | 2024-10-06 22:42:42.421 BST [56M] INFO:  -> Cached DNS queries: 0
pihole  | 2024-10-06 22:42:42.421 BST [56M] INFO:  -> Forwarded DNS queries: 0
pihole  | 2024-10-06 22:42:42.421 BST [56M] INFO:  -> Blocked DNS queries: 0
pihole  | 2024-10-06 22:42:42.421 BST [56M] INFO:  -> Unknown DNS queries: 0
pihole  | 2024-10-06 22:42:42.421 BST [56M] INFO:  -> Unique domains: 0
pihole  | 2024-10-06 22:42:42.421 BST [56M] INFO:  -> Unique clients: 0
pihole  | 2024-10-06 22:42:42.421 BST [56M] INFO:  -> DNS cache records: 0
pihole  | 2024-10-06 22:42:42.421 BST [56M] INFO:  -> Known forward destinations: 0
pihole  | 2024-10-06 22:42:42.436 BST [56M] WARNING: Insufficient permissions to set system time (CAP_SYS_TIME required), NTP client not available
pihole  | 2024-10-06 22:42:42.436 BST [56/T57] INFO: NTP server listening on 0.0.0.0:123 (IPv4)
pihole  | 2024-10-06 22:42:42.436 BST [56/T58] INFO: NTP server listening on :::123 (IPv6)
pihole  | 2024-10-06 22:42:42.436 BST [56M] INFO: FTL is running as user pihole (UID 1000)
pihole  | 2024-10-06 22:42:42.436 BST [56M] INFO: Reading certificate from /etc/pihole/tls.pem ...
pihole  | 2024-10-06 22:42:42.437 BST [56M] INFO: Using SSL/TLS certificate file /etc/pihole/tls.pem
pihole  | 2024-10-06 22:42:42.437 BST [56M] INFO: Restored 0 API sessions from the database
pihole  | 2024-10-06 22:42:42.438 BST [56M] INFO: Blocking status is enabled
pihole  | 2024-10-06 22:42:42.537 BST [56/T59] INFO: Compiled 0 allow and 0 deny regex for 0 client in 0.0 msec
pihole  | 2024-10-06 22:42:45.519 BST [56M] INFO: Asked to terminate by "N/A" (PID 168, user root UID 0)
pihole  | 2024-10-06 22:42:45.541 BST [56/T62] INFO: Terminating timer thread
pihole  | 2024-10-06 22:42:45.542 BST [56/T59] INFO: Terminating database thread
pihole  | 2024-10-06 22:42:45.770 BST [56M] INFO: Finished final database update
pihole  | 2024-10-06 22:42:45.770 BST [56M] INFO: Waiting for threads to join
pihole  | 2024-10-06 22:42:45.770 BST [56M] INFO: Thread housekeeper (1) is idle, terminating it.
pihole  | 2024-10-06 22:42:45.770 BST [56M] INFO: Thread dns-client (2) is idle, terminating it.
pihole  | 2024-10-06 22:42:45.770 BST [56M] INFO: All threads joined
pihole  | 2024-10-06 22:42:45.770 BST [56M] INFO: Stored 0 API sessions in the database
pihole  | 2024-10-06 22:42:46.439 BST [56M] INFO: ########## FTL terminated after 4s 21ms  (code 0)! ##########
pihole  | 
pihole  |   [i] pihole-FTL exited with status 0
pihole  | 
pihole  |   [i] Container will now stop or restart depending on your restart policy
pihole  |       https://docs.docker.com/engine/containers/start-containers-automatically/#use-a-restart-policy
pihole  | 
pihole exited with code 0
```

</details>

<details>
<summary>`docker exec -it pihole killall --signal 11 pihole-FTL`</summary>

```
pihole  | 2024-10-06 22:43:19.256 BST [56M] INFO: ########## FTL started on 6178e7ef0dd1! ##########
pihole  | 2024-10-06 22:43:19.256 BST [56M] INFO: FTL branch: development
pihole  | 2024-10-06 22:43:19.256 BST [56M] INFO: FTL version: vDev-e558f79
pihole  | 2024-10-06 22:43:19.256 BST [56M] INFO: FTL commit: e558f798
pihole  | 2024-10-06 22:43:19.256 BST [56M] INFO: FTL date: 2024-10-05 18:06:26 +0200
pihole  | 2024-10-06 22:43:19.256 BST [56M] INFO: FTL user: pihole
pihole  | 2024-10-06 22:43:19.256 BST [56M] INFO: Compiled for linux/amd64 (compiled on CI) using cc (Alpine 13.2.1_git20240309) 13.2.1 20240309
pihole  | 2024-10-06 22:43:19.257 BST [56M] INFO: Wrote config file:
pihole  | 2024-10-06 22:43:19.257 BST [56M] INFO:  - 150 total entries
pihole  | 2024-10-06 22:43:19.257 BST [56M] INFO:  - 147 entries are default
pihole  | 2024-10-06 22:43:19.257 BST [56M] INFO:  - 3 entries are modified
pihole  | 2024-10-06 22:43:19.257 BST [56M] INFO:  - 0 entries are forced through environment
pihole  | 2024-10-06 22:43:19.258 BST [56M] INFO: Parsed config file /etc/pihole/pihole.toml successfully
pihole  | 2024-10-06 22:43:19.258 BST [56M] WARNING: Insufficient permissions to set process priority to -10 (CAP_SYS_NICE required), process priority remains at 0
pihole  | 2024-10-06 22:43:19.258 BST [56M] INFO: PID of FTL process: 56
pihole  | 2024-10-06 22:43:19.258 BST [56M] INFO: listening on 0.0.0.0 port 53
pihole  | 2024-10-06 22:43:19.258 BST [56M] INFO: listening on :: port 53
pihole  | 2024-10-06 22:43:19.259 BST [56M] INFO: PID of FTL process: 56
pihole  | 2024-10-06 22:43:19.259 BST [56M] INFO: Database version is 19
pihole  | 2024-10-06 22:43:19.259 BST [56M] INFO: Database successfully initialized
pihole  | 2024-10-06 22:43:19.260 BST [56M] INFO: Imported 0 queries from the on-disk database (it has 0 rows)
pihole  | 2024-10-06 22:43:19.260 BST [56M] INFO: Parsing queries in database
pihole  | 2024-10-06 22:43:19.260 BST [56M] INFO: Imported 0 queries from the long-term database
pihole  | 2024-10-06 22:43:19.260 BST [56M] INFO:  -> Total DNS queries: 0
pihole  | 2024-10-06 22:43:19.260 BST [56M] INFO:  -> Cached DNS queries: 0
pihole  | 2024-10-06 22:43:19.260 BST [56M] INFO:  -> Forwarded DNS queries: 0
pihole  | 2024-10-06 22:43:19.260 BST [56M] INFO:  -> Blocked DNS queries: 0
pihole  | 2024-10-06 22:43:19.260 BST [56M] INFO:  -> Unknown DNS queries: 0
pihole  | 2024-10-06 22:43:19.260 BST [56M] INFO:  -> Unique domains: 0
pihole  | 2024-10-06 22:43:19.260 BST [56M] INFO:  -> Unique clients: 0
pihole  | 2024-10-06 22:43:19.260 BST [56M] INFO:  -> DNS cache records: 0
pihole  | 2024-10-06 22:43:19.260 BST [56M] INFO:  -> Known forward destinations: 0
pihole  | 2024-10-06 22:43:19.276 BST [56M] WARNING: Insufficient permissions to set system time (CAP_SYS_TIME required), NTP client not available
pihole  | 2024-10-06 22:43:19.276 BST [56/T57] INFO: NTP server listening on 0.0.0.0:123 (IPv4)
pihole  | 2024-10-06 22:43:19.276 BST [56/T58] INFO: NTP server listening on :::123 (IPv6)
pihole  | 2024-10-06 22:43:19.276 BST [56M] INFO: FTL is running as user pihole (UID 1000)
pihole  | 2024-10-06 22:43:19.276 BST [56M] INFO: Reading certificate from /etc/pihole/tls.pem ...
pihole  | 2024-10-06 22:43:19.276 BST [56M] INFO: Using SSL/TLS certificate file /etc/pihole/tls.pem
pihole  | 2024-10-06 22:43:19.277 BST [56M] INFO: Restored 0 API sessions from the database
pihole  | 2024-10-06 22:43:19.278 BST [56M] INFO: Blocking status is enabled
pihole  | 2024-10-06 22:43:19.377 BST [56/T59] INFO: Compiled 0 allow and 0 deny regex for 0 client in 0.0 msec
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: ---------------------------->  FTL crashed!  <----------------------------
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: Please report a bug at https://github.com/pi-hole/FTL/issues
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: and include in your report already the following details:
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: FTL has been running for 8 seconds
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: FTL branch: development
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: FTL version: vDev-e558f79
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: FTL commit: e558f798
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: FTL date: 2024-10-05 18:06:26 +0200
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: FTL user: started as pihole, ended as pihole
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: Compiled for linux/amd64 (compiled on CI) using cc (Alpine 13.2.1_git20240309) 13.2.1 20240309
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: Process details: MID: 56
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO:                  PID: 56
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO:                  TID: 56
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO:                  Name: pihole-FTL
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: Received signal: Segmentation fault
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO:      at address: 0xa8
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO:      with code:  Unknown (0)
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: !!! INFO: pihole-FTL has not been compiled with glibc/backtrace support, not generating one !!!
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: ------ Listing content of directory /dev/shm ------
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: File Mode User:Group      Size  Filename
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: rwxrwxrwx root:root       280   .
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: rwxr-xr-x root:root       340   ..
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: rw------- pihole:pihole   569K  FTL-fifo-log
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: rw------- pihole:pihole     4K  FTL-per-client-regex
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: rw------- pihole:pihole    20K  FTL-dns-cache
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: rw------- pihole:pihole     8K  FTL-overTime
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: rw------- pihole:pihole   295K  FTL-queries
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: rw------- pihole:pihole    29K  FTL-upstreams
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: rw------- pihole:pihole    86K  FTL-clients
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: rw------- pihole:pihole     4K  FTL-domains
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: rw------- pihole:pihole    82K  FTL-strings
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: rw------- pihole:pihole   136   FTL-settings
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: rw------- pihole:pihole   304   FTL-counters
pihole  | 2024-10-06 22:43:27.354 BST [56M] INFO: rw------- pihole:pihole    88   FTL-lock
pihole  | 2024-10-06 22:43:27.355 BST [56M] INFO: ---------------------------------------------------
pihole  | 2024-10-06 22:43:27.355 BST [56M] INFO: Please also include some lines from above the !!!!!!!!! header.
pihole  | 2024-10-06 22:43:27.355 BST [56M] INFO: Thank you for helping us to improve our FTL engine!
pihole  | 2024-10-06 22:43:27.355 BST [56M] INFO: Waiting for threads to join
pihole  | 2024-10-06 22:43:27.355 BST [56M] INFO: Thread database (0) is idle, terminating it.
pihole  | 2024-10-06 22:43:27.355 BST [56M] INFO: Thread housekeeper (1) is idle, terminating it.
pihole  | 2024-10-06 22:43:27.355 BST [56M] INFO: Thread dns-client (2) is idle, terminating it.
pihole  | 2024-10-06 22:43:27.355 BST [56M] INFO: Thread timer (3) is idle, terminating it.
pihole  | 2024-10-06 22:43:27.355 BST [56M] INFO: All threads joined
pihole  | 2024-10-06 22:43:27.355 BST [56M] INFO: Stored 0 API sessions in the database
pihole  | 2024-10-06 22:43:28.285 BST [56M] INFO: ########## FTL terminated after 9s 29ms  (code 1)! ##########
pihole  | 
pihole  |   [i] pihole-FTL exited with status 1
pihole  | 
pihole  |   [i] Container will now stop or restart depending on your restart policy
pihole  |       https://docs.docker.com/engine/containers/start-containers-automatically/#use-a-restart-policy
pihole  | 
pihole exited with code 1
```

</details>

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_