### PR TITLE
Remove tini from image, we don't need it as we're handling all the ex…

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -33,7 +33,6 @@ RUN apk add --no-cache \
     psmisc \
     shadow \
     sudo \
-    tini \
     tzdata \
     unzip \
     wget 
@@ -95,4 +94,4 @@ FROM ${FTL_SOURCE}-ftl-install AS final
 
 HEALTHCHECK CMD dig +short +norecurse +retry=0 @127.0.0.1 pi.hole || exit 1
 
-ENTRYPOINT ["/sbin/tini", "--", "start.sh"]
+ENTRYPOINT ["start.sh"]


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

After some more handling added in #1649 - we realised that `tini` isn't actually doing anything. Lets save `0.1Mb` in image size! 🙃 

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_