### PR TITLE
logrotate: fix permissions on configfile

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -53,7 +53,7 @@ RUN cd /etc/.pihole && \
     install -Dm755 -t /opt/pihole ./advanced/Scripts/*.sh && \
     install -Dm755 -t /opt/pihole ./advanced/Scripts/COL_TABLE && \
     install -Dm755 -d /etc/pihole && \
-    install -Dm644 -t /etc/pihole ./advanced/Templates/logrotate && \
+    install -Dm600 -t /etc/pihole ./advanced/Templates/logrotate && \
     install -Dm755 -d /var/log/pihole && \
     install -Dm755 -d /var/lib/logrotate && \
     install -Dm755 -t /usr/local/bin pihole && \


### PR DESCRIPTION
this should fix
https://github.com/pi-hole/docker-pi-hole/issues/1387

## Description
permissions on conifgfile of logrotate are wrong

## Motivation and Context
this was easy to fix

## How Has This Been Tested?
manually in docker container

## Types of changes
installation of logrotate file places the config now in mode 0600

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
