### PR TITLE
Bump base image to Alpine 3.21

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG FTL_SOURCE=remote
-ARG alpine_version="3.20" 
+ARG alpine_version="3.21"
 FROM alpine:${alpine_version} AS base
 # https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
 


### PR DESCRIPTION
## Description
Update Alpine base from 3.20 to 3.21

**Note:**
The `tests/Dockerfile` wasn't update yet, because at the moment there is no `docker-cli` image for *alpine3.21* available: https://hub.docker.com/_/docker/tags.

Testing with the previous `docker.io/library/docker:27.1.1-cli-alpine3.20` worked.
I also successfully tested with the most recent image (`docker.io/library/docker:27.4.0-rc.4-cli-alpine3.20`), but we can wait for a `-cli-alpine3.21` image.

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_