### PR TITLE
Bake debugging requirements into the nightly image for ease of debugging

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -35,7 +35,17 @@ RUN apk add --no-cache \
     sudo \
     tzdata \
     unzip \
-    wget 
+    wget
+
+# For nightly images, we install gdb and screen for ease of debugging (this is
+# not included in the default image to keep it small), and also prepare the
+# system for a core dump. Furthermore, we already add the required signal
+# instructions to the gdb config file
+RUN if [ "${PIHOLE_DOCKER_TAG}" = "nightly" ]; then \
+    apk add --no-cache gdb screen && \
+    echo "ulimit -c unlimited" >> /etc/profile && \
+    echo "handle SIGHUP nostop SIGPIPE nostop SIGTERM nostop SIG32 nostop SIG33 nostop SIG34 nostop SIG35 nostop SIG36 nostop SIG37 nostop SIG38 nostop SIG39 nostop SIG40 nostop SIG41 nostop" > /root/.gdbinit; \
+    fi
 
 ADD https://ftl.pi-hole.net/macvendor.db /macvendor.db
 COPY crontab.txt /crontab.txt


### PR DESCRIPTION
## Description
See title, the instructions are in taken from https://deploy-preview-338--pihole-docs.netlify.app/ftldns/gdb/

## Motivation and Context
Related to https://github.com/pi-hole/FTL/issues/2112#issuecomment-2564287394

## How Has This Been Tested?
Locally build container, confirmed `gdb` is working. The image increases quite significantly in size which is why I am not suggesting this for any production, just the hard development tag. I added the installation rather early to benefit from `Docker`'s cache so changes due to a more recent FTL binary, etc., do not need to download much. 

```
$ docker images
REPOSITORY           TAG               IMAGE ID       CREATED          SIZE
<none>               nightly           59b8682afb79   7 seconds ago    144MB
<none>               local             c888fe0ab5a6   36 seconds ago   91.2MB
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
