### PR TITLE
Update README.md to document FTLCONF_RATE_LIMIT environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ There are other environment variables if you want to customize various things in
 | `CUSTOM_CACHE_SIZE` | `10000` | Number | Set the cache size for dnsmasq. Useful for increasing the default cache size or to set it to 0. Note that when `DNSSEC` is "true", then this setting is ignored.
 | `FTL_CMD` | `no-daemon` | `no-daemon -- <dnsmasq option>` | Customize the options with which dnsmasq gets started. e.g. `no-daemon -- --dns-forward-max 300` to increase max. number of concurrent dns queries on high load setups. |
 | `FTLCONF_[SETTING]` | unset | As per documentation | Customize pihole-FTL.conf with settings described in the [FTLDNS Configuration page](https://docs.pi-hole.net/ftldns/configfile/). For example, to customize LOCAL_IPV4, ensure you have the `FTLCONF_LOCAL_IPV4` environment variable set.
+| `FTLCONF_RATE_LIMIT` | `1000/60` | queries/seconds| Control FTL's query rate-limiting. Rate-limited queries are answered with a REFUSED reply and not further processed by FTL [About per-client rate limiting](https://docs.pi-hole.net/ftldns/configfile/#rate_limit).
+
 
 ### Experimental Variables
 | Variable | Default | Value | Description |


### PR DESCRIPTION
Document FTLCONF_RATE_LIMIT environment variable

## Description
Documenting FTLCONF_RATE_LIMIT environment variable in docker readme.md

Confirmed FTLCONF_RATE_LIMIT works in stable, it's described elsewhere https://github.com/pi-hole/docker-pi-hole/issues/1098#issuecomment-1127820699 and described in discussions. 

## Motivation and Context
It was a little hard to find, and someone's work implementing this should be better known.

## How Has This Been Tested?
Applied to current docker instance locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
Documentation.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
