### PR TITLE
Utilise FTL's native config upgrade functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ services:
     volumes:
       # For persisting Pi-hole's databases and common configuration file
       - './etc-pihole:/etc/pihole'
-      # Uncomment the below if you have custom dnsmasq config files that you want to persist. Not needed for most starting fresh with Pi-hole v6. If you're upgrading from v5 you and used it before your should keep it enabled at the first v6 container start for a complete migration. Can be turned off afterwards.
+      # Uncomment the below if you have custom dnsmasq config files that you want to persist. Not needed for most starting fresh with Pi-hole v6. If you're upgrading from v5 you and have used this directory before, you should keep it enabled for the first v6 container start to allow for a complete migration. It can be removed afterwards
       #- './etc-dnsmasq.d:/etc/dnsmasq.d'
     cap_add:
       # See https://github.com/pi-hole/docker-pi-hole#note-on-capabilities

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ services:
     volumes:
       # For persisting Pi-hole's databases and common configuration file
       - './etc-pihole:/etc/pihole'
-      # Uncomment the below if you have custom dnsmasq config files that you want to persist. Not needed for most.
+      # Uncomment the below if you have custom dnsmasq config files that you want to persist. Not needed for most starting fresh with Pi-hole v6. If you're upgrading from v5 you and used it before your should keep it enabled at the first v6 container start for a complete migration. Can be turned off afterwards.
       #- './etc-dnsmasq.d:/etc/dnsmasq.d'
     cap_add:
       # See https://github.com/pi-hole/docker-pi-hole#note-on-capabilities

--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -181,7 +181,7 @@ migrate_v5_configs() {
 
     # Print the output of the FTL migration prefacing every line with six
     # spaces for alignment with other container output. Replace the first line to match the style of the other messages
-    # We supress the message about environment variables as these will be set on FTL's first real start
+    # We suppress the message about environment variables as these will be set on FTL's first real start
     printf "%b" "${FTLoutput}\\n" | sed 's/^/      /' | sed 's/      Migrating config to Pi-hole v6.0 format/  [i] Migrating config to Pi-hole v6.0 format/' | sed 's/- 0 entries are forced through environment//'
 
     # Print a blank line for separation

--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -116,10 +116,12 @@ migrate_gravity() {
         echo "  [i] Gravity will now be run to create the database"
         pihole -g
     else
-        echo "  [i] Existing gravity database found"
+        echo "  [i] Existing gravity database found - schema will be upgraded if necessary"
         # source the migration script and run the upgrade function
         source /etc/.pihole/advanced/Scripts/database_migration/gravity-db.sh
-        upgrade_gravityDB "${gravityDBfile}" "/etc/pihole"
+        local upgradeOutput
+        upgradeOutput=$(upgrade_gravityDB "${gravityDBfile}" "/etc/pihole")
+        printf "%b" "${upgradeOutput}\\n" | sed 's/^/     /'
     fi
     echo ""
 }
@@ -179,7 +181,8 @@ migrate_v5_configs() {
 
     # Print the output of the FTL migration prefacing every line with six
     # spaces for alignment with other container output. Replace the first line to match the style of the other messages
-    printf "%b" "${FTLoutput}" | sed 's/^/      /' | sed 's/      Migrating config to Pi-hole v6.0 format/  [i] Migrating config to Pi-hole v6.0 format/'
+    # We supress the message about environment variables as these will be set on FTL's first real start
+    printf "%b" "${FTLoutput}\\n" | sed 's/^/      /' | sed 's/      Migrating config to Pi-hole v6.0 format/  [i] Migrating config to Pi-hole v6.0 format/' | sed 's/- 0 entries are forced through environment//'
 
     # Print a blank line for separation
     echo ""

--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -147,7 +147,7 @@ ftl_config() {
     setup_web_password
 }
 
-migrate_dnsmasq_d_contents() {
+migrate_v5_configs() {
     # Previously, Pi-hole created a number of files in /etc/dnsmasq.d
     # During migration, their content is copied into the new single source of
     # truth file /etc/pihole/pihole.toml and the old files are moved away to
@@ -167,6 +167,21 @@ migrate_dnsmasq_d_contents() {
 
     mv /etc/dnsmasq.d/0{1,2,4,5}-pihole*.conf "${V6_CONF_MIGRATION_DIR}/" 2>/dev/null || true
     mv /etc/dnsmasq.d/06-rfc6761.conf "${V6_CONF_MIGRATION_DIR}/" 2>/dev/null || true
+    echo ""
+
+    # Finally, after everything is in place, we can create the new config file
+    # /etc/pihole/pihole.toml
+    # This file will be created with the default settings unless the user has
+    # changed settings via setupVars.conf or the other dnsmasq files moved above
+    # During migration, setupVars.conf is moved to /etc/pihole/migration_backup_v6
+    local FTLoutput
+    FTLoutput=$(pihole-FTL migrate v6)
+
+    # Print the output of the FTL migration prefacing every line with six
+    # spaces for alignment with other container output. Replace the first line to match the style of the other messages
+    printf "%b" "${FTLoutput}" | sed 's/^/      /' | sed 's/      Migrating config to Pi-hole v6.0 format/  [i] Migrating config to Pi-hole v6.0 format/'
+
+    # Print a blank line for separation
     echo ""
 }
 

--- a/src/start.sh
+++ b/src/start.sh
@@ -87,7 +87,10 @@ start() {
   # fi
 
   pihole updatechecker
-  pihole -v
+  local versionsOutput
+  versionsOutput=$(pihole -v)
+  echo "  [i] Version info:"
+  printf "%b" "${versionsOutput}\\n" | sed 's/^/      /' 
   echo ""
 
   if [ "${TAIL_FTL_LOG:-1}" -eq 1 ]; then

--- a/src/start.sh
+++ b/src/start.sh
@@ -77,15 +77,7 @@ start() {
   while ! grep -q '########## FTL started' /var/log/pihole/FTL.log; do
     sleep 0.5
   done
-
-  # If we are migrating from v5 to v6, we now need to run the basic configuration step that we deferred earlier
-  # This is because pihole-FTL needs to migrate the config files before we can perform the basic configuration checks
-  # if [[ ${v5_volume} -eq 1 ]]; then
-  #   echo "  [i] Starting deferred FTL Configuration"
-  #   ftl_config
-  #   echo ""
-  # fi
-
+  
   pihole updatechecker
   local versionsOutput
   versionsOutput=$(pihole -v)

--- a/src/start.sh
+++ b/src/start.sh
@@ -21,13 +21,8 @@ start() {
   # FTL Will handle the migration of the config files
   if [[ -f /etc/pihole/setupVars.conf && ! -f /etc/pihole/pihole.toml ]]; then
     echo "  [i] v5 files detected that have not yet been migrated to v6"
-    echo "  [i] Deferring additional configuration until after FTL has started"
-    echo "  [i] Note: It is normal to see \"Config file /etc/pihole/pihole.toml not available (r): No such file or directory\" in the logs at this point"
     echo ""
-    # We need to migrate the dnsmasq.d contents so that FTL can read them in properly
-    migrate_dnsmasq_d_contents
-    v5_volume=1
-
+    migrate_v5_configs
   fi
 
   # ===========================
@@ -37,12 +32,9 @@ start() {
   # If PIHOLE_UID is set, modify the pihole user's id to match
   set_uid_gid
 
-  # Only run the next step if we are not migrating from v5 to v6
-  if [[ ${v5_volume} -eq 0 ]]; then
-    # Configure FTL with any environment variables if needed
-    echo "  [i] Starting FTL configuration"
-    ftl_config
-  fi
+  # Configure FTL with any environment variables if needed
+  echo "  [i] Starting FTL configuration"
+  ftl_config
 
   # Install additional packages inside the container if requested
   install_additional_packages
@@ -88,11 +80,11 @@ start() {
 
   # If we are migrating from v5 to v6, we now need to run the basic configuration step that we deferred earlier
   # This is because pihole-FTL needs to migrate the config files before we can perform the basic configuration checks
-  if [[ ${v5_volume} -eq 1 ]]; then
-    echo "  [i] Starting deferred FTL Configuration"
-    ftl_config
-    echo ""
-  fi
+  # if [[ ${v5_volume} -eq 1 ]]; then
+  #   echo "  [i] Starting deferred FTL Configuration"
+  #   ftl_config
+  #   echo ""
+  # fi
 
   pihole updatechecker
   pihole -v


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Taking inspiration from https://github.com/pi-hole/pi-hole/pull/5830 - we use the new functionality within FTL to ensure V5 configs are properly migrated to V6. 

Also taken a couple of tricks to improve the output of the docker container.

Example output from a new v6 container with 5 volumes:

```txt
pihole  |   [i] v5 files detected that have not yet been migrated to v6
pihole  | 
pihole  |   [i] Migrating dnsmasq configuration files
pihole  | 
pihole  |   [i] Migrating config to Pi-hole v6.0 format
pihole  |       Reading legacy config files from /etc/pihole/pihole-FTL.conf
pihole  |          PIDFILE: Empty path is not possible, using default
pihole  |          SETUPVARSFILE: Empty path is not possible, using default
pihole  |          GRAVITYDB: Empty path is not possible, using default
pihole  |          WEBROOT: Empty path is not possible, using default
pihole  |          WEBHOME: Empty path is not possible, using default
pihole  |          API_INFO_LOG: Empty path is not possible, using default
pihole  |          WEBDOMAIN: Empty path is not possible, using default
pihole  |       Moving /etc/pihole/pihole-FTL.conf to /etc/pihole/migration_backup_v6/pihole-FTL.conf
pihole  |       Migrating config from /etc/pihole/setupVars.conf
pihole  |       setupVars.conf:WEBPASSWORD -> Setting webserver.api.pwhash to 06eae68f1ca3493598cb993d99a9e64179d6e740627f8426a2bfa9ed9a26733f
pihole  |       setupVars.conf:BLOCKING_ENABLED -> Setting dns.blocking.active to true
pihole  |       setupVars.conf:TEMPERATURE_LIMIT -> Not set
pihole  |       setupVars.conf:TEMPERATURE_UNIT -> Not set
pihole  |       setupVars.conf:WEBUIBOXEDLAYOUT -> Not set
pihole  |       setupVars.conf:WEBTHEME -> Not set
pihole  |       setupVars.conf:PIHOLE_DNS_1 -> Setting dns.upstreams[1] = 8.8.8.8
pihole  |       setupVars.conf:PIHOLE_DNS_2 -> Setting dns.upstreams[2] = 8.8.4.4
pihole  |       setupVars.conf:PIHOLE_DOMAIN -> Not set
pihole  |       setupVars.conf:DNS_FQDN_REQUIRED -> Not set
pihole  |       setupVars.conf:DNS_FQDN_REQUIRED -> Not set
pihole  |       setupVars.conf:DNS_bogusPriv -> Not set
pihole  |       setupVars.conf:DNSSEC -> Not set
pihole  |       setupVars.conf:PIHOLE_INTERFACE -> Setting dns.interface to eth0
pihole  |       setupVars.conf:HOSTRECORD -> Not set
pihole  |       setupVars.conf:DNSMASQ_LISTENING -> Not set
pihole  |       setupVars.conf:REV_SERVER -> Not set
pihole  |       setupVars.conf:DHCP_ACTIVE -> Not set
pihole  |       setupVars.conf:DHCP_START -> Not set
pihole  |       setupVars.conf:DHCP_END -> Not set
pihole  |       setupVars.conf:DHCP_ROUTER -> Not set
pihole  |       setupVars.conf:DHCP_LEASETIME -> Not set
pihole  |       setupVars.conf:DHCP_IPv6 -> Not set
pihole  |       setupVars.conf:DHCP_RAPID_COMMIT -> Not set
pihole  |       setupVars.conf:queryLogging -> Not set
pihole  |       setupVars.conf:GRAVITY_TMPDIR -> Not set
pihole  |       setupVars.conf:WEB_PORTS -> Not set
pihole  |       Moved /etc/pihole/setupVars.conf to /etc/pihole/migration_backup_v6/setupVars.conf
pihole  |       setupVars.conf migration complete
pihole  |       Moving /etc/pihole/custom.list to /etc/pihole/migration_backup_v6/custom.list
pihole  |       Config initialized with webserver ports 80 (HTTP) and 443 (HTTPS), IPv6 support is enabled
pihole  |       Wrote config file:
pihole  |        - 151 total entries
pihole  |        - 145 entries are default
pihole  |        - 6 entries are modified
pihole  |        
pihole  |       Config file written to /etc/pihole/pihole.toml
pihole  | 
pihole  |   [i] Setting up user & group for the pihole user
pihole  |   [i] PIHOLE_UID not set in environment, using default (100)
pihole  |   [i] PIHOLE_GID not set in environment, using default (101)
pihole  | 
pihole  |   [i] Starting FTL configuration
pihole  |   [i] Assigning password defined by Environment Variable
pihole  |   [i] Starting crond for scheduled scripts. Randomizing times for gravity and update checker
pihole  | 
pihole  |   [i] Ensuring logrotate script exists in /etc/pihole
pihole  | 
pihole  |   [i] Gravity migration checks
pihole  |   [i] No adlist file found, creating one with a default blocklist
pihole  |   [i] Existing gravity database found - schema will be upgraded if necessary
pihole  |         Upgrading gravity database from version 15 to 16
pihole  |         Upgrading gravity database from version 16 to 17
pihole  |         Upgrading gravity database from version 17 to 18
pihole  |         Upgrading gravity database from version 18 to 19
pihole  | 
pihole  |   [i] pihole-FTL pre-start checks
pihole  |   [i] Setting capabilities on pihole-FTL where possible
pihole  |   [i] Applying the following caps to pihole-FTL:
pihole  |         * CAP_CHOWN
pihole  |         * CAP_NET_BIND_SERVICE
pihole  |         * CAP_NET_RAW
pihole  |         * CAP_NET_ADMIN
pihole  | 
pihole  |   [i] Starting pihole-FTL (no-daemon) as pihole
pihole  | 
pihole  |   [i] Version info:
pihole  |       Core
pihole  |           Version is efaa0f4 (Latest: null)
pihole  |           Branch is development
pihole  |           Hash is efaa0f42 (Latest: efaa0f42)
pihole  |       Web
pihole  |           Version is 603f35d (Latest: null)
pihole  |           Branch is development
pihole  |           Hash is 603f35d5 (Latest: 603f35d5)
pihole  |       FTL
pihole  |           Version is vDev-d01a265 (Latest: null)
pihole  |           Branch is development
pihole  |           Hash is d01a2652 (Latest: d01a2652)
pihole  | 
pihole  | 2025-01-14 18:17:57.592 GMT [67M] INFO: ########## FTL started on c5127ed948b8! ##########
pihole  | 2025-01-14 18:17:57.592 GMT [67M] INFO: FTL branch: development
pihole  | 2025-01-14 18:17:57.592 GMT [67M] INFO: FTL version: vDev-d01a265
pihole  | 2025-01-14 18:17:57.592 GMT [67M] INFO: FTL commit: d01a2652
pihole  | 2025-01-14 18:17:57.592 GMT [67M] INFO: FTL date: 2025-01-14 18:59:14 +0100
pihole  | 2025-01-14 18:17:57.592 GMT [67M] INFO: FTL user: pihole
pihole  | 2025-01-14 18:17:57.592 GMT [67M] INFO: Compiled for linux/arm64/v8 (compiled on CI) using cc (Alpine 14.2.0) 14.2.0
pihole  | 2025-01-14 18:17:57.683 GMT [67M] INFO: 2 FTLCONF environment variables found (2 used, 0 invalid, 0 ignored)
pihole  | 2025-01-14 18:17:57.683 GMT [67M] INFO:    [✓] FTLCONF_webserver_api_password is used
pihole  | 2025-01-14 18:17:57.683 GMT [67M] INFO:    [✓] FTLCONF_dns_upstreams is used
pihole  | 2025-01-14 18:17:57.683 GMT [67M] INFO: Wrote config file:
pihole  | 2025-01-14 18:17:57.683 GMT [67M] INFO:  - 151 total entries
pihole  | 2025-01-14 18:17:57.683 GMT [67M] INFO:  - 145 entries are default
pihole  | 2025-01-14 18:17:57.683 GMT [67M] INFO:  - 6 entries are modified
pihole  | 2025-01-14 18:17:57.683 GMT [67M] INFO:  - 1 entry is forced through environment
pihole  | 2025-01-14 18:17:57.686 GMT [67M] INFO: Parsed config file /etc/pihole/pihole.toml successfully
pihole  | 2025-01-14 18:17:57.686 GMT [67M] WARNING: Insufficient permissions to set process priority to -10 (CAP_SYS_NICE required), process priority remains at 0
```

Subsequent runs will not display the output messages as the configs will have already been migrated.

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_