### PR TITLE
Remove unused DHCP_ACTIVE and fix shellcheck warnings

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -43,8 +43,9 @@ check_branch_exists() {
         url="https://github.com/pi-hole/${repo}/blob/${branch}/README.md"
     fi
 
-    local http_code=$(curl -sI "$url" -o /dev/null -w "%{http_code}")
-    if [ $http_code -ne 200 ]; then
+    local http_code
+    http_code=$(curl -sI "$url" -o /dev/null -w "%{http_code}")
+    if [ "${http_code}" -ne 200 ]; then
         echo "Error: $repo branch '$branch' not found. Exiting."
         exit 1
     fi
@@ -121,7 +122,7 @@ done
 
 # Execute the docker build command
 echo "Executing command: $DOCKER_BUILD_CMD"
-eval $DOCKER_BUILD_CMD
+eval "${DOCKER_BUILD_CMD}"
 
 # Check exit code of previous command
 if [ $? -ne 0 ]; then
@@ -133,5 +134,5 @@ if [ $? -ne 0 ]; then
 else
     echo ""
     echo "Successfully built Docker image with tag '$TAG'"
-    docker images $TAG
+    docker images "${TAG}"
 fi

--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -38,7 +38,7 @@ set_uid_gid() {
     if [ -n "${PIHOLE_UID}" ]; then
         if [[ ${currentUid} -ne ${PIHOLE_UID} ]]; then
             echo "  [i] Changing ID for user: pihole (${currentUid} => ${PIHOLE_UID})"
-            usermod -o -u ${PIHOLE_UID} pihole
+            usermod -o -u "${PIHOLE_UID}" pihole
         else
             echo "  [i] ID for user pihole is already ${PIHOLE_UID}, no need to change"
         fi
@@ -52,7 +52,7 @@ set_uid_gid() {
     if [ -n "${PIHOLE_GID}" ]; then
         if [[ ${currentGid} -ne ${PIHOLE_GID} ]]; then
             echo "  [i] Changing ID for group: pihole (${currentGid} => ${PIHOLE_GID})"
-            groupmod -o -g ${PIHOLE_GID} pihole
+            groupmod -o -g "${PIHOLE_GID}" pihole
         else
             echo "  [i] ID for group pihole is already ${PIHOLE_GID}, no need to change"
         fi
@@ -219,13 +219,12 @@ fix_capabilities() {
             echo "        * ${i}"
         done
 
-        setcap ${CAP_STR:1}+ep "$(which pihole-FTL)" || ret=$?
+        setcap "${CAP_STR:1}"+ep "$(which pihole-FTL)" || ret=$?
 
         if [[ $DHCP_READY == false ]] && [[ $FTLCONF_dhcp_active == true ]]; then
             # DHCP is requested but NET_ADMIN is not available.
             echo "ERROR: DHCP requested but NET_ADMIN is not available. DHCP will not be started."
             echo "      Please add cap_net_admin to the container's capabilities or disable DHCP."
-            DHCP_ACTIVE='false'
             setFTLConfigValue dhcp.active false
         fi
 

--- a/src/start.sh
+++ b/src/start.sh
@@ -67,7 +67,7 @@ start() {
   echo "  [i] Starting pihole-FTL ($FTL_CMD) as ${DNSMASQ_USER}"
   echo ""
 
-  capsh --user=$DNSMASQ_USER --keep=1 -- -c "/usr/bin/pihole-FTL $FTL_CMD >/dev/null" &
+  capsh --user="${DNSMASQ_USER}" --keep=1 -- -c "/usr/bin/pihole-FTL $FTL_CMD >/dev/null" &
   # Notes on above:
   # - DNSMASQ_USER default of pihole is in Dockerfile & can be overwritten by runtime container env
   # - /var/log/pihole/pihole*.log has FTL's output that no-daemon would normally print in FG too
@@ -103,7 +103,7 @@ start() {
     # Get the line number
     startFrom=$(grep -n '########## FTL started' /var/log/pihole/FTL.log | tail -1 | cut -d: -f1)
     # Start the tail from the line number and background it
-    tail --follow=name -n +${startFrom} /var/log/pihole/FTL.log &
+    tail --follow=name -n +"${startFrom}" /var/log/pihole/FTL.log &
   else
     echo "  [i] FTL log output is disabled. Remove the Environment variable TAIL_FTL_LOG, or set it to 1 to enable FTL log output."
   fi
@@ -158,7 +158,7 @@ stop() {
     sleep 10
   fi
 
-  exit ${FTL_EXIT_CODE}
+  exit "${FTL_EXIT_CODE}"
 
 }
 


### PR DESCRIPTION
Fixes various `shellcheck` warnings (mostly about missing quotes to prevent globbing) and removes unused `DHCP_ACTIVE` variable.