### PR TITLE
Add test to output FTL's version information

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -96,7 +96,8 @@ RUN if   [ "$TARGETPLATFORM" = "linux/amd64" ];    then FTLARCH=amd64; \
     && if [ "${FTL_BRANCH}" = "master" ]; then URL="https://github.com/pi-hole/ftl/releases/latest/download"; else URL="https://ftl.pi-hole.net/${FTL_BRANCH}"; fi \    
     && curl -sSL "${URL}/pihole-FTL-${FTLARCH}" -o /usr/bin/pihole-FTL \
     && chmod +x /usr/bin/pihole-FTL \
-    && readelf -h /usr/bin/pihole-FTL || (echo "Error with downloaded FTL binary" && exit 1)
+    && readelf -h /usr/bin/pihole-FTL || (echo "Error with downloaded FTL binary" && exit 1) \
+    && /usr/bin/pihole-FTL  -vv
 
 FROM base AS local-ftl-install
 # pihole-FTL must be built from source and copied to the src directory first!

--- a/test/tests/test_general.py
+++ b/test/tests/test_general.py
@@ -12,6 +12,10 @@ def test_pihole_gid_env_var(docker):
     func = docker.run("id -g pihole")
     assert "456" in func.stdout
 
+def test_pihole_FTL_version(docker):
+    func = docker.run("pihole-FTL -vv")
+    assert func.rc == 0
+    assert "Version:" in func.stdout
 
 # Wait 5 seconds for startup, then kill the start.sh script
 # Finally, grep the FTL log to see if it has been shut down cleanly

--- a/test/tests/test_general.py
+++ b/test/tests/test_general.py
@@ -12,7 +12,7 @@ def test_pihole_gid_env_var(docker):
     func = docker.run("id -g pihole")
     assert "456" in func.stdout
 
-def test_pihole_FTL_version(docker):
+def test_pihole_ftl_version(docker):
     func = docker.run("pihole-FTL -vv")
     assert func.rc == 0
     assert "Version:" in func.stdout


### PR DESCRIPTION
Adds a simply test to check for the output of `pihole-FTL -vv`. Main use is probably debugging.