### PR TITLE
Improve default docker compose file to include SYS_TIME and SYS_NICE

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ services:
       # See https://github.com/pi-hole/docker-pi-hole#note-on-capabilities
       # Required if you are using Pi-hole as your DHCP server, else not needed
       - NET_ADMIN
+      # Required if you are using Pi-hole as your NTP client to be able to set the host's system time
+      - SYS_TIME
+      # Optional, if Pi-hole should get some more processing time
+      - SYS_NICE
     restart: unless-stopped
 ```
 
@@ -286,7 +290,7 @@ The webserver and DNS service inside the container can be customized if necessar
 
 ## Note on Capabilities
 
-[FTLDNS](https://docs.pi-hole.net/ftldns/in-depth/#linux-capabilities) expects to have the following capabilities available:
+Pi-hole's DNS core (FTL) expects to have the following capabilities available:
 
 - `CAP_NET_BIND_SERVICE`: Allows FTLDNS binding to TCP/UDP sockets below 1024 (specifically DNS service on port 53)
 - `CAP_NET_RAW`: use raw and packet sockets (needed for handling DHCPv6 requests, and verifying that an IP is not in use before leasing it)


### PR DESCRIPTION
Adds `SYS_TIME` and `SYS_NICE` to the docker compose example file. 
Brought up in https://github.com/pi-hole/docker-pi-hole/issues/1717