### PR TITLE
Allow custom web interface URI for Pi-hole admin

### DIFF
--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -156,6 +156,8 @@ ftl_config() {
         if [ -d "/var/www/html/admin" ]; then
             echo "Moving /var/www/html/admin to /var/www/html/$WEBHOME"
             mv /var/www/html/admin "/var/www/html/$WEBHOME"
+            # Link to hardcoded scripts detects path
+            ln -s "/var/www/html/$WEBHOME" /var/www/html/admin
         fi
     fi
 

--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -145,6 +145,19 @@ ftl_config() {
         echo "  [i] No DNS upstream set in environment or config file, defaulting to Google DNS"
         setFTLConfigValue "dns.upstreams" "[\"8.8.8.8\", \"8.8.4.4\"]"
     fi
+    
+    # If the function getFTLConfigValue("webserver.paths.webhome") returns a value different from "/admin/",
+    # Then, move the directory "/var/www/html/admin" to the new location.
+    if WEBHOME=$(getFTLConfigValue "webserver.paths.webhome") && [[ "$WEBHOME" != "/admin/" ]]; then
+        # Remove leading slash if present
+        WEBHOME="${WEBHOME#/}" 
+        
+        # Move the existing admin directory to the new location
+        if [ -d "/var/www/html/admin" ]; then
+            echo "Moving /var/www/html/admin to /var/www/html/$WEBHOME"
+            mv /var/www/html/admin "/var/www/html/$WEBHOME"
+        fi
+    fi
 
     setup_web_password
 }


### PR DESCRIPTION
### Overview

This pull request adds support for a configurable web interface URI in the Pi-hole Docker container. With this update, users can specify where the Pi-hole admin interface is served by setting the environment variable FTLCONF_webserver_paths_webhome.

### Motivation

In many deployment scenarios—especially those using a reverse proxy for HTTPS—it is beneficial to serve the admin interface under a custom URI. For example, by setting FTLCONF_webserver_paths_webhome=/pihole/ in your docker-compose file, the admin interface will be available at /pihole/ instead of the default /admin/.

### How to Enable

To activate this feature, add the following line to your docker-compose file:

FTLCONF_webserver_paths_webhome=/pihole/


This instructs the container to serve the admin interface from the specified path.

### Testing

Please test the change in your environment by defining the variable and verifying that the Pi-hole admin interface is correctly accessible from the new URI.

### Conclusion

This update provides enhanced flexibility for configuring the Pi-hole Docker container, making it easier to integrate with custom routing or proxy setups.

