### PR TITLE
Reintroduce missed docker secret handling (Redo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ To explicitly set no password, set `FTLCONF_webserver_api_password: ''`.
 | `FTLCONF_[SETTING]` | unset | As per documentation | Customize pihole.toml with settings described in the [API Documentation](https://docs.pi-hole.net/api).<br><br>Replace `.` with `_`, e.g for `dns.dnssec=true` use `FTLCONF_dns_dnssec: 'true'`.<br/>Array type configs should be delimited with `;`.|
 | `PIHOLE_UID` | `1000` | Number | Overrides image's default pihole user id to match a host user id.<br/>**IMPORTANT**: id must not already be in use inside the container!|
 | `PIHOLE_GID` | `1000` | Number | Overrides image's default pihole group id to match a host group id.<br/>**IMPORTANT**: id must not already be in use inside the container!|
+| `WEBPASSWORD_FILE` | unset| `<Docker secret path>` | Set an Admin password using [Docker secrets](https://docs.docker.com/engine/swarm/secrets/). If `FTLCONF_webserver_api_password` is set, `WEBPASSWORD_FILE` is ignored. If `FTLCONF_webserver_api_password` is empty, and `WEBPASSWORD_FILE` is set to a valid readable file path, then `FTLCONF_webserver_api_password` will be set to the contents of `WEBPASSWORD_FILE`. |
 
 ### Advanced Variables
 

--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -189,6 +189,11 @@ migrate_v5_configs() {
 }
 
 setup_web_password() {
+    if [ -z "${FTLCONF_webserver_api_password+x}" ] && [ -n "${WEBPASSWORD_FILE}" ] && [ -r "${WEBPASSWORD_FILE}" ]; then
+        echo "  [i] Setting FTLCONF_webserver_api_password from file"
+        export FTLCONF_webserver_api_password=$(<"${WEBPASSWORD_FILE}")
+    fi
+
     # If FTLCONF_webserver_api_password is not set
     if [ -z "${FTLCONF_webserver_api_password+x}" ]; then
         # Is this already set to something other than blank (default) in FTL's config file? (maybe in a volume mount)


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

The V6 image was rebuilt from scratch - and this feature was accidentally missed. 

Reproduces functionality of https://github.com/pi-hole/docker-pi-hole/pull/584


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_