### PR TITLE
WEBPASSWORD_FILE is mounted to /run/secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ To explicitly set no password, set `FTLCONF_webserver_api_password: ''`.
 | `FTLCONF_[SETTING]` | unset | As per documentation | Customize pihole.toml with settings described in the [API Documentation](https://docs.pi-hole.net/api).<br><br>Replace `.` with `_`, e.g for `dns.dnssec=true` use `FTLCONF_dns_dnssec: 'true'`.<br/>Array type configs should be delimited with `;`.|
 | `PIHOLE_UID` | `1000` | Number | Overrides image's default pihole user id to match a host user id.<br/>**IMPORTANT**: id must not already be in use inside the container!|
 | `PIHOLE_GID` | `1000` | Number | Overrides image's default pihole group id to match a host group id.<br/>**IMPORTANT**: id must not already be in use inside the container!|
-| `WEBPASSWORD_FILE` | unset| `<Docker secret path>` | Set an Admin password using [Docker secrets](https://docs.docker.com/engine/swarm/secrets/). If `FTLCONF_webserver_api_password` is set, `WEBPASSWORD_FILE` is ignored. If `FTLCONF_webserver_api_password` is empty, and `WEBPASSWORD_FILE` is set to a valid readable file path, then `FTLCONF_webserver_api_password` will be set to the contents of `WEBPASSWORD_FILE`. |
+| `WEBPASSWORD_FILE` | unset| `<Docker secret file>` | Set an Admin password using [Docker secrets](https://docs.docker.com/engine/swarm/secrets/). If `FTLCONF_webserver_api_password` is set, `WEBPASSWORD_FILE` is ignored. If `FTLCONF_webserver_api_password` is empty, and `WEBPASSWORD_FILE` is set to a valid readable file, then `FTLCONF_webserver_api_password` will be set to the contents of `WEBPASSWORD_FILE`. |
 
 ### Advanced Variables
 

--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -189,9 +189,9 @@ migrate_v5_configs() {
 }
 
 setup_web_password() {
-    if [ -z "${FTLCONF_webserver_api_password+x}" ] && [ -n "${WEBPASSWORD_FILE}" ] && [ -r "${WEBPASSWORD_FILE}" ]; then
+    if [ -z "${FTLCONF_webserver_api_password+x}" ] && [ -n "${WEBPASSWORD_FILE}" ] && [ -r "/run/secrets/${WEBPASSWORD_FILE}" ]; then
         echo "  [i] Setting FTLCONF_webserver_api_password from file"
-        export FTLCONF_webserver_api_password=$(<"${WEBPASSWORD_FILE}")
+        export FTLCONF_webserver_api_password=$(<"/run/secrets/${WEBPASSWORD_FILE}")
     fi
 
     # If FTLCONF_webserver_api_password is not set

--- a/src/start.sh
+++ b/src/start.sh
@@ -11,8 +11,6 @@ TRAP_TRIGGERED=0
 
 start() {
 
-  local v5_volume=0
-
   # The below functions are all contained in bash_functions.sh
   # shellcheck source=/dev/null
   . /usr/bin/bash_functions.sh


### PR DESCRIPTION
Build on top of https://github.com/pi-hole/docker-pi-hole/pull/1750

If using secrets with Docker swarm/compose, they are usually referenced by the file path **on the host** and mounted by  default to `/run/secret/my_secret`. 
This PR amends the Readme and changes the check to the appropriate location within the container.

https://docs.docker.com/compose/how-tos/use-secrets/#use-secrets
https://docs.docker.com/engine/swarm/secrets/#how-docker-manages-secrets