### PR TITLE
fix: alpine bash issue

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -43,13 +43,13 @@ RUN apk add --no-cache \
 
 # Creates symbolic links for specific Bash commands that point to Busybox,
 # and adds these commands to the Bash configuration to avoid compatibility issues on Alpine Linux
-ARG BASH_COMMANDS="test ["
-RUN for CMD in ${BASH_COMMANDS}; do \
+ARG DISABLE_BASH_INTEGRATED_CMDS="test ["
+RUN for CMD in ${DISABLE_BASH_INTEGRATED_CMDS}; do \
     ln -s /bin/busybox /usr/local/bin/${CMD} && \
     echo "enable -n ${CMD}" >> /etc/bash/bashrc && \
-    echo "enable -n ${CMD}" >> /etc/bash_noninteractive.sh; \
-    done && chmod +x /etc/bash_noninteractive.sh
-ENV BASH_ENV=/etc/bash_noninteractive.sh
+    echo "enable -n ${CMD}" >> /etc/bash/noninteractive; \
+    done
+ENV BASH_ENV=/etc/bash/noninteractive
 
 # For nightly images, we install gdb and screen for ease of debugging (this is
 # not included in the default image to keep it small), and also prepare the

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -41,6 +41,15 @@ RUN apk add --no-cache \
     unzip \
     wget
 
+# Fix alpine bash issue
+RUN ln -sf /bin/busybox      /usr/local/bin/test         && \
+    ln -sf /bin/busybox      /usr/local/bin/[            && \
+    echo "enable -n test" >> /etc/bash_noninteractive.sh && \
+    echo "enable -n ["    >> /etc/bash_noninteractive.sh && \
+    chmod +x                 /etc/bash_noninteractive.sh && \
+    cat /etc/bash_noninteractive.sh >> /etc/bash/bashrc
+ENV BASH_ENV=/etc/bash_noninteractive.sh
+
 # For nightly images, we install gdb and screen for ease of debugging (this is
 # not included in the default image to keep it small), and also prepare the
 # system for a core dump. Furthermore, we already add the required signal

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -41,13 +41,14 @@ RUN apk add --no-cache \
     unzip \
     wget
 
-# Fix alpine bash issue
-RUN ln -sf /bin/busybox      /usr/local/bin/test         && \
-    ln -sf /bin/busybox      /usr/local/bin/[            && \
-    echo "enable -n test" >> /etc/bash_noninteractive.sh && \
-    echo "enable -n ["    >> /etc/bash_noninteractive.sh && \
-    chmod +x                 /etc/bash_noninteractive.sh && \
-    cat /etc/bash_noninteractive.sh >> /etc/bash/bashrc
+# Creates symbolic links for specific Bash commands that point to Busybox,
+# and adds these commands to the Bash configuration to avoid compatibility issues on Alpine Linux
+ARG BASH_COMMANDS="test ["
+RUN for CMD in ${BASH_COMMANDS}; do \
+    ln -s /bin/busybox /usr/local/bin/${CMD} && \
+    echo "enable -n ${CMD}" >> /etc/bash/bashrc && \
+    echo "enable -n ${CMD}" >> /etc/bash_noninteractive.sh; \
+    done && chmod +x /etc/bash_noninteractive.sh
 ENV BASH_ENV=/etc/bash_noninteractive.sh
 
 # For nightly images, we install gdb and screen for ease of debugging (this is


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This creates a symlink for the `test` and `[` commands to make them executable via `busybox` and not `coreutils`. It writes commands to disable the `bash` internal `test` and `[` commands both in the `bashrc` (for interactive sessions) and in a separate sh file that is used as a script for non-interactive sessions (specified via an env). This way, at least the execution of `bash` internal commands like `test` and `[` can be prevented and these `busybox` commands can be used instead.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This (hopefully) fixes: #1767

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I tested this on an Ubuntu 20.04 VM with an outdated containerd.io package to be able to reproduce the bash alpine issue and test its fix. More details [here](https://github.com/pi-hole/docker-pi-hole/issues/1767#issuecomment-2718596501).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
