### PR TITLE
Set day of week for gravity update to be the same as bare metal install

### DIFF
--- a/src/crontab.txt
+++ b/src/crontab.txt
@@ -1,3 +1,3 @@
-59 1  * * 6 PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole updateGravity >/var/log/pihole/pihole_updateGravity.log || cat /var/log/pihole/pihole_updateGravity.log
+59 1  * * 7 PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole updateGravity >/var/log/pihole/pihole_updateGravity.log || cat /var/log/pihole/pihole_updateGravity.log
 00 00 * * * PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole flush once quiet
 59 17 * * * PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole updatechecker


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Set day of week for gravity update to be the same as bare metal install

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Consistency between docker and bare metal 

Should avoid [this](https://www.reddit.com/r/pihole/s/TguKhvt5yh)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [*] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
