### PR TITLE
Prevent container from starting on old versions of docker due to incompatibility with newer versions of alpine

### DIFF
--- a/src/start.sh
+++ b/src/start.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [ ! -x /bin/sh ]; then
+  echo "Executable test for /bin/sh failed. Your Docker version is too old to run Alpine 3.14+ and Pi-hole. You must upgrade Docker.";
+  exit 1;
+fi
+
 if [ "${PH_VERBOSE:-0}" -gt 0 ]; then
   set -x
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds a test when running the Docker image that checks if the `if [...` logic works. If not, the user will see a message in the `docker logs` that their Docker is too old and will be prompted to update.
Furthermore, the container is terminated with `exit 1`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This (hopefully) fixes: #1767

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I tested this on an Ubuntu 20.04 VM with an outdated containerd.io package to be able to reproduce the bash alpine issue and test its fix. More details [here](https://github.com/pi-hole/docker-pi-hole/issues/1767#issuecomment-2718596501) or [here](https://github.com/pi-hole/docker-pi-hole/issues/1767#issuecomment-2746305744)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
