### PR TITLE
Fix sunday cronjob

### DIFF
--- a/src/crontab.txt
+++ b/src/crontab.txt
@@ -1,3 +1,3 @@
-59 1  * * 7 PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole updateGravity >/var/log/pihole/pihole_updateGravity.log || cat /var/log/pihole/pihole_updateGravity.log
+59 1  * * 0 PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole updateGravity >/var/log/pihole/pihole_updateGravity.log || cat /var/log/pihole/pihole_updateGravity.log
 00 00 * * * PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole flush once quiet
 59 17 * * * PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole updatechecker


### PR DESCRIPTION
## Description

#1788 introduced an error: BusyBox crond does not support `7` for Sundays. Changing it to `0` fixes the issue.

Before:
```
d6063bb15688:/# crond -f -d 8
crond: crond (busybox 1.36.1) started, log level 8
crond: user root: parse error at 7
```

After:
```
d6063bb15688:/# vi /var/spool/cron/crontabs/root # replace 7 with 0
d6063bb15688:/# crond -f -d 8
crond: crond (busybox 1.36.1) started, log level 8
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
