### PR TITLE
Caps

### DIFF
--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -251,9 +251,12 @@ fix_capabilities() {
 
         setcap "${CAP_STR:1}"+ep "$(which pihole-FTL)" || ret=$?
 
-        if [[ $ret -ne 0 && "${DNSMASQ_USER:-pihole}" != "root" ]]; then
-            echo "  [!] ERROR: Unable to set capabilities for pihole-FTL. Cannot run as non-root."
-            echo "            If you are seeing this error, please set the environment variable 'DNSMASQ_USER' to the value 'root'"
+        if [[ $ret -ne 0 ]]; then
+            echo "  [!] ERROR: Unable to set capabilities for pihole-FTL. "
+            if [[ "${DNSMASQ_USER:-pihole}" != "root" ]]; then
+                echo "            Cannot run as non-root."
+                echo "            If you are seeing this error, please set the environment variable 'DNSMASQ_USER' to the value 'root'"
+            fi
             exit 1
         fi
     else

--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -257,9 +257,9 @@ fix_capabilities() {
             exit 1
         fi
     else
-        echo "  [!] ERROR: Unable to set capabilities for pihole-FTL."
+        echo "  [!] WARNING: No capabilities for pihole-FTL available."
+        echo "            Not all functions may work as expected."
         echo "            Please ensure that the container has the required capabilities."
-        exit 1
     fi
     echo ""
 }


### PR DESCRIPTION
Improves the capability check. Inspired by https://github.com/pi-hole/docker-pi-hole/issues/1085#issuecomment-2816349021

It does three things

1.  Warn about missing `NET_ADMIN` even when this would be the only cap that would be checked and could not be granted.
2. Allow to start even if `CAP_STR` is empty.  See the linked comment above. The error was wrong in the first place, as it did not check if we failed to grant the caps but if `CAP_STR` is empty. And it is empty if the caps are not available to the container.
3. Split the check for the return code of setting the caps of `pihole-FTL` from checking the user. This should be a two-step process.