### PR TITLE
Use CODEOWNERS instead of deprecated dependbot/reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+*       @pi-hole/docker-maintainers"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,6 @@ updates:
       day: saturday
       time: "10:00"
     target-branch: development
-    reviewers:
-      - "pi-hole/docker-maintainers"
   - package-ecosystem: "docker"
     directory: "/src/"
     schedule:
@@ -17,8 +15,6 @@ updates:
       day: saturday
       time: "10:00"
     target-branch: development
-    reviewers:
-      - "pi-hole/docker-maintainers"
   - package-ecosystem: pip
     directory: "/test"
     schedule:
@@ -27,5 +23,3 @@ updates:
       time: "10:00"
     open-pull-requests-limit: 10
     target-branch: development
-    reviewers:
-      - "pi-hole/docker-maintainers"


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Dependabot will drop the 'reviewer' option. One should use CODEOWNER file instead.
See https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/