### PR TITLE
Improve Tips section: clarify webserver port conflict handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,13 @@ Here is a rundown of other arguments for your docker-compose / docker run.
 - Port conflicts?  Stop your server's existing DNS / Web services.
   - Don't forget to stop your services from auto-starting again after you reboot.
   - Ubuntu users see below for more detailed information.
+  - If only ports 80 and/or 443 are in use, you have two options:
+    - Change the container's port mapping by adjusting the Docker `-p` flags or the `ports:` section in the compose file. For example, change `- "80:80/tcp"` to `- "8080:80/tcp"` to expose the container’s internal HTTP port 80 as 8080 on the host.
+    - Or, when running the container in `network_mode: host`, where port mappings are not available, change the ports used by the Pi-hole web server using the `FTLCONF_webserver_port` environment variable.<br>
+      Example:<br>
+      `FTLCONF_webserver_port: '8080o,[::]:8080o,8443os,[::]:8443os'`<br>
+      This makes the web interface available on HTTP port 8080 and HTTPS port 8443 for both IPv4 and IPv6.
+    - **Note:** This only applies to web interface ports (80 and 443). DNS (53), DHCP (67), and NTP (123) ports must still be handled via Docker port mappings or host networking.
 - Docker's default network mode `bridge` isolates the container from the host's network. This is a more secure setting, but requires setting the Pi-hole DNS option for _Interface listening behavior_ to "Listen on all interfaces, permit all origins".
 - If you're using a Red Hat based distribution with an SELinux Enforcing policy, add `:z` to line with volumes.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR updates the "Tips and Tricks" section of the README to clarify how to resolve port conflicts specifically related to the Pi-hole web interface (ports 80 and 443). It introduces two options for users encountering conflicts:

* Adjusting the container's port mapping via `-p` or `docker-compose`
* Setting the `FTLCONF_webserver_port` environment variable, which is especially helpful when using `network_mode: host`, where port mapping is not possible

A concrete example of `FTLCONF_webserver_port` usage is provided, along with a clear note that this method applies only to the web interface—not to DNS, DHCP, or NTP services.

## Motivation and Context

When running Pi-hole in `network_mode: host`, I encountered a port conflict and initially believed the web server port could not be changed—since this capability isn't mentioned in the public documentation or Pi-hole's main config guides.

The `FTLCONF_webserver_port` variable is only visible from a running instance’s internal documentation I belive. Making this variable and its usage more discoverable would save others from unnecessary troubleshooting, especially those using host networking.

## How Has This Been Tested?
Tested locally by:

* Running Pi-hole in `network_mode: host`
* Setting `FTLCONF_webserver_port` to custom ports (e.g., `8080o,[::]:8080o,8443os,[::]:8443os`)
* Confirmed web UI was accessible on the specified ports (HTTP on 8080, HTTPS on 8443 for both IPv4 and IPv6)

No impact to core Pi-hole behavior or DNS functionality.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
