### PR TITLE
Build ARM on ARM and add ARM back to test suite

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,9 @@ updates:
       time: "10:00"
     target-branch: development
   - package-ecosystem: "docker"
-    directory: "/src/"
+    directories: 
+      - "/src/"
+      - "/test/"
     schedule:
       interval: "weekly"
       day: saturday

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -16,11 +16,23 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        platform: [linux/amd64, linux/386, linux/arm/v6, linux/arm/v7, linux/arm64, linux/riscv64]
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/386
+            runner: ubuntu-latest
+          - platform: linux/arm/v6
+            runner: ubuntu-24.04-arm
+          - platform: linux/arm/v7
+            runner: ubuntu-24.04-arm
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+          - platform: linux/riscv64
+            runner: ubuntu-24.04-arm
           
     steps:
       - name: Prepare name for digest up/download

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,16 +8,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Not testing i386 and RISCV
-        # Currently there are no docker-cli images for these architectures
         include:
           - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/386
             runner: ubuntu-latest
           - platform: linux/arm/v6
             runner: ubuntu-24.04-arm
           - platform: linux/arm/v7
             runner: ubuntu-24.04-arm
           - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+          - platform: linux/riscv64
             runner: ubuntu-24.04-arm
     steps:
     - name: Checkout Repo

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,6 +8,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Not testing i386 and RISCV
+        # Currently there are no docker-cli images for these architectures
         include:
           - platform: linux/amd64
             runner: ubuntu-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,16 +4,19 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        # Official docker images for docker are only available for amd64 and arm64
-        # TODO: Look at: https://github.com/docker-library/official-images#architectures-other-than-amd64
-        # Is testing on all platforms really necessary?
-        # Disabled arm64 tests for the time being, something is wrong with the test config and the volumes are getting shared between the test containers on different architectures
-        #platform: [linux/amd64, linux/arm64]
-        platform: [linux/amd64]
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm/v6
+            runner: ubuntu-24.04-arm
+          - platform: linux/arm/v7
+            runner: ubuntu-24.04-arm
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v4

--- a/build-and-test.sh
+++ b/build-and-test.sh
@@ -14,6 +14,7 @@ PLATFORM="${PLATFORM:-linux/amd64}"
 # generate and build dockerfile
 docker buildx build --load --platform=${PLATFORM} --tag image_pipenv --file test/Dockerfile test/
 docker run --rm \
+    --platform=${PLATFORM} \
     --volume /var/run/docker.sock:/var/run/docker.sock \
     --volume "$(pwd):/$(pwd)" \
     --workdir "$(pwd)" \

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,7 +1,14 @@
-ARG alpine_version="3.22"
-ARG docker_version="28.2.2"
+FROM alpine:3.22 AS base-cli
 
-FROM docker:${docker_version}-cli-alpine${alpine_version}
+RUN apk add --no-cache \
+    ca-certificates \
+    openssh-client \
+    git \
+    docker-cli \
+    docker-cli-buildx \
+    docker-cli-compose
+
+FROM base-cli
 
 COPY --chmod=0755 ./cmd.sh /usr/local/bin/cmd.sh
 COPY requirements.txt /root/

--- a/test/cmd.sh
+++ b/test/cmd.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eux
 
-docker buildx build ./src --build-arg TARGETPLATFORM="${TARGETPLATFORM}" --tag pihole:${GIT_TAG} --no-cache
+docker buildx build ./src --platform "${TARGETPLATFORM}" --build-arg TARGETPLATFORM="${TARGETPLATFORM}" --tag pihole:${GIT_TAG} --no-cache
 docker images pihole:${GIT_TAG}
 
 # auto-format the pytest code

--- a/test/tests/test_general.py
+++ b/test/tests/test_general.py
@@ -24,7 +24,7 @@ def test_pihole_ftl_version(docker):
 def test_pihole_ftl_clean_shutdown(docker):
     func = docker.run(
         """
-        sleep 5
+        sleep 15
         killall --signal 15 start.sh
         sleep 5
         grep 'terminated' /var/log/pihole/FTL.log


### PR DESCRIPTION
- Speeds up building of the images by running ARM-builds on ARM-runners
- Add back tests for ARM architecture (we publish those images, we should test them).
Note. there are no docker-cli images for i386 and RISCV