### PR TITLE
Add support for test RISCV64 and 386 architecture by adding Docker CLI via Alpine's APK instead of a Docker CLI image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,9 @@ updates:
       time: "10:00"
     target-branch: development
   - package-ecosystem: "docker"
-    directory: "/src/"
+    directories: 
+      - "/src/"
+      - "/test/"
     schedule:
       interval: "weekly"
       day: saturday

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,16 +8,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Not testing i386 and RISCV
-        # Currently there are no docker-cli images for these architectures
         include:
           - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/386
             runner: ubuntu-latest
           - platform: linux/arm/v6
             runner: ubuntu-24.04-arm
           - platform: linux/arm/v7
             runner: ubuntu-24.04-arm
           - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+          - platform: linux/riscv64
             runner: ubuntu-24.04-arm
     steps:
     - name: Checkout Repo

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,7 +1,14 @@
-ARG alpine_version="3.22"
-ARG docker_version="28.2.2"
+FROM alpine:3.22 AS base-cli
 
-FROM docker:${docker_version}-cli-alpine${alpine_version}
+RUN apk add --no-cache \
+    ca-certificates \
+    openssh-client \
+    git \
+    docker-cli \
+    docker-cli-buildx \
+    docker-cli-compose
+
+FROM base-cli
 
 COPY --chmod=0755 ./cmd.sh /usr/local/bin/cmd.sh
 COPY requirements.txt /root/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds support for RISCv64 and 386 by adding a section to the Dockerfile that installs docker-cli via Alpine's apk. Additionally, tagging for individual architectures is also used.

| before | after |
|:---:|:---:|
| ![Screenshot 2025-06-11 at 13-22-22 Build Image and Test · LizenzFass78851_pi-hole_docker-pi-hole@c04d56d](https://github.com/user-attachments/assets/e5b24279-2d96-4fda-9e0a-27b570e1e1d2) | ![Screenshot 2025-06-11 at 13-22-28 Build Image and Test · LizenzFass78851_pi-hole_docker-pi-hole@47663a4](https://github.com/user-attachments/assets/7e6ce63c-1fc3-4ce8-b49a-9c458e769ddb) |

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To support #1843 with this pr directly

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
In my fork of the repository, I manually triggered the execution of the test actions.
(test with workflow_dispatch)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
