### PR TITLE
Pull in iproute2

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -40,7 +40,7 @@ RUN apk add --no-cache \
     git \
     # Install grep to avoid issues in pihole -w/b with the default busybox grep
     grep \
-    iproute2-ss \
+    iproute2 \
     jq \
     libcap \
     logrotate \


### PR DESCRIPTION
## Description

Pull in iproute2 in the Dockerfile

## Motivation and Context

Busybox's ip command supports less features than the full version provided by iproute2.

Iproute2/iproute is a dependency on full installs on apt and rpm using systems.

This will allow use additional features (including json output) on the ip command.

The immediate motivation is not break piholeDebug.sh on Docker installs by [pihole#6303](https://github.com/pi-hole/pi-hole/pull/6303) to address [ftl#2605](https://github.com/pi-hole/FTL/issues/2525).

Also unsupported (by busybox) ip features are already used in:

https://github.com/pi-hole/pi-hole/blob/8a97a1433a5e3cade8e308fa1b956780dc68198c/advanced/Scripts/piholeARPTable.sh#L61

## How Has This Been Tested?
Tested on docker 26.1.5 on trixie
Also all tests in `.build-and-test.sh` passing

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] My code follows the code style of this project.
- [N/A] My change requires a change to the documentation.
- [N/A] I have updated the documentation accordingly.
