### PR TITLE
Build all containers from a fixed base image

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,17 +1,7 @@
 # syntax=docker/dockerfile:1
 ARG FTL_SOURCE=remote
 # Pull Stable images
-FROM alpine:3.22 AS base-stable
-FROM base-stable AS base-386
-FROM base-stable AS base-amd64
-FROM base-stable AS base-arm
-FROM base-stable AS base-arm64
-# Pull Edge images
-FROM alpine:edge AS base-edge
-FROM base-edge   AS base-riscv64
-# Use the base image for the current architecture
-FROM base-${TARGETARCH} AS base
-# https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
+FROM alpine:3.22 AS base
 
 ARG TARGETPLATFORM
 ARG WEB_BRANCH="development"


### PR DESCRIPTION
Currently, all images were build on `alpine:3.22` except `riscv`which was based on `edge`. This distinction was introduced by https://github.com/pi-hole/docker-pi-hole/pull/1511 as of then there was only one image type (`edge`) for `riscv`. But not tagged images exist also for `riscv` (see https://hub.docker.com/r/riscv64/alpine/tags). 
Using `edge`when it's not needed can cause issues as it's considered unstable. 