### PR TITLE
Prevent cosmetic issue where component versions are sometimes labeled as commit hashes

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -60,9 +60,12 @@ COPY crontab.txt /crontab.txt
 # Add PADD to the container, too.
 ADD --chmod=0755 https://raw.githubusercontent.com/${PADD_FORK}/PADD/${PADD_BRANCH}/padd.sh /usr/local/bin/padd
 
-# download a the main repos from github
-RUN git clone --depth 1 --single-branch --branch ${WEB_BRANCH} https://github.com/${WEB_FORK}/web.git /var/www/html/admin && \
-    git clone --depth 1 --single-branch --branch ${CORE_BRANCH} https://github.com/${CORE_FORK}/pi-hole.git /etc/.pihole
+# download a the main repos from github 
+#if the branch is master we reset to the latest tag as sometimes the master branch contains meta changes that have not been tagged.                                        
+RUN git clone --depth 5 --single-branch --branch ${WEB_BRANCH} https://github.com/${WEB_FORK}/web.git /var/www/html/admin && \    
+    if [ "${WEB_BRANCH}" = "master" ]; then cd /var/www/html/admin && git reset --hard "$(git describe --tags --abbrev=0)"; fi && \
+    git clone --depth 5 --single-branch --branch ${CORE_BRANCH} https://github.com/${CORE_FORK}/pi-hole.git /etc/.pihole && \    
+    if [ "${CORE_BRANCH}" = "master" ]; then cd /etc/.pihole && git reset --hard "$(git describe --tags --abbrev=0)"; fi
 
 RUN cd /etc/.pihole && \
     install -Dm755 -d /opt/pihole && \


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Occasionally core and web `master` branches can have additional commits ahead of the latest tagged commit - not often, but often enough to make me kick myself when I tag this repo.

This copies the behaviour of bare metal, where the local repository is hard reset to the latest tag.

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_