### PR TITLE
Remove ncat dependency

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -35,7 +35,6 @@ RUN apk add --no-cache \
     libcap \
     logrotate \
     ncurses \
-    nmap-ncat \
     procps-ng \
     psmisc \
     shadow \


### PR DESCRIPTION
Removes the `netcat` package.
It's not needed in `core` anymore (https://github.com/pi-hole/pi-hole/pull/6343) and I don't see where we need `nc` or `ncat` in the image.

It's likely a leftover from the previous debian image as stated in https://github.com/pi-hole/docker-pi-hole/issues/1359