### PR TITLE
Ensure all orphan FTL files are cleaned on startup

### DIFF
--- a/src/start.sh
+++ b/src/start.sh
@@ -52,9 +52,8 @@ start() {
   migrate_gravity
 
   echo "  [i] pihole-FTL pre-start checks"
-  # Remove possible leftovers from previous pihole-FTL processes
-  rm -f /dev/shm/FTL-* 2>/dev/null
-  rm -f /run/pihole/FTL.sock
+  # Run the post stop script to cleanup any remaining artifacts from a previous run
+  sh /opt/pihole/pihole-FTL-poststop.sh
 
   fix_capabilities
   sh /opt/pihole/pihole-FTL-prestart.sh
@@ -134,6 +133,8 @@ stop() {
   if ! [[ "${FTL_EXIT_CODE}" =~ ^[0-9]+$ ]]; then
     FTL_EXIT_CODE=1
   fi
+
+  sh /opt/pihole/pihole-FTL-poststop.sh
 
   echo ""
   echo "  [i] pihole-FTL exited with status $FTL_EXIT_CODE"


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Utilises the FTL post-stop cleanup script to ensure any files left from a previous run are cleaned up.

This is part of the issue happening in #1789 - the other part is a possible bug in FTL, but that will need to be addressed in a separate PR there...

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_