### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig is awesome: https://editorconfig.org/
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = tab
+tab_width = 4
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.yml]
+tab_width = 2
+
+[*.md]
+tab_width = 2

--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -1,0 +1,18 @@
+name: Editorconfig-Checker
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  editorconfig-checker:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Get editorconfig-checker
+      uses: editorconfig-checker/action-editorconfig-checker@main # tag v1.0.0 is really out of date
+
+    - name: Run editorconfig-checker
+      run: editorconfig-checker


### PR DESCRIPTION
Adds the same `editorconfig` file as we have in the core repo to unify file syntax. Also adds a github action to check for validity of the fiel style.