### PR TITLE
Drop the development tag, reduce dupliation in build yaml

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -40,17 +40,20 @@ jobs:
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
-      - name: Checkout Repo
+      - &checkout-repo
+        name: Checkout Repo
         if: github.event_name != 'schedule'
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
-      - name: Checkout dev branch if scheduled
+      - &checkout-dev
+        name: Checkout dev branch if scheduled
         if: github.event_name == 'schedule'
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
         with:
           ref: development
 
-      - name: Docker meta
+      - &docker-meta
+        name: Docker meta
         id: meta
         uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f #v5.8.0
         with:
@@ -62,17 +65,18 @@ jobs:
             latest=${{ startsWith(github.ref, 'refs/tags/') }}
           tags: |
             type=schedule,pattern=nightly
-            type=ref,event=branch,enable=${{ github.event_name != 'schedule' }},pattern=nightly
+            type=raw,value=nightly,enable=${{ github.event_name == 'push' }}
             type=ref,event=tag
 
-      -
+      - &login-dockerhub
         name: Login to Docker Hub
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef #v3.6.0
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PASS }}
-      -
+
+      - &login-ghcr
         name: Login to GitHub Container Registry
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef #v3.6.0
         with:
@@ -85,7 +89,8 @@ jobs:
         with:
           platforms: ${{ matrix.platform}}
 
-      - name: Set up Docker Buildx
+      - &setup-buildx
+        name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
 
       - name: Build container and push by digest
@@ -126,15 +131,8 @@ jobs:
     needs:
       - build
     steps:
-      - name: Checkout Repo
-        if: github.event_name != 'schedule'
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
-
-      - name: Checkout dev branch if scheduled
-        if: github.event_name == 'schedule'
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
-        with:
-          ref: development
+      - *checkout-repo
+      - *checkout-dev
 
       - name: Download digests
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
@@ -143,38 +141,10 @@ jobs:
           pattern: digests-*
           merge-multiple: true
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f #v5.8.0
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          images: |
-            ${{ env.dockerhub }}
-            ${{ env.ghcr }}
-          flavor: |
-            latest=${{ startsWith(github.ref, 'refs/tags/') }}
-          tags: |
-            type=schedule,pattern=nightly
-            type=ref,event=branch,enable=${{ github.event_name != 'schedule' }},pattern=nightly
-            type=ref,event=tag
-
-      -
-        name: Login to Docker Hub
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef #v3.6.0
-        with:
-          registry: docker.io
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_PASS }}
-      -
-        name: Login to GitHub Container Registry
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef #v3.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - *setup-buildx
+      - *docker-meta
+      - *login-dockerhub
+      - *login-ghcr
 
       - name: Create manifest list and push (DockerHub and GitHub Container Registry)
         working-directory: /tmp/digests

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -12,7 +12,7 @@ on:
 env:
   dockerhub: ${{ secrets.DOCKERHUB_NAMESPACE }}/pihole
   ghcr: ghcr.io/${{ github.repository_owner }}/pihole
-  components_branch: ${{ github.event_name == 'schedule' && 'development' || 'master' }}
+  components_branch: ${{ github.event_name == 'release' && 'master' || 'development' }}
 
 jobs:
   build:
@@ -62,7 +62,7 @@ jobs:
             latest=${{ startsWith(github.ref, 'refs/tags/') }}
           tags: |
             type=schedule,pattern=nightly
-            type=ref,event=branch,enable=${{ github.event_name != 'schedule' }}
+            type=ref,event=branch,enable=${{ github.event_name != 'schedule' }},pattern=nightly
             type=ref,event=tag
 
       -
@@ -148,7 +148,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f #v5.8.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           images: |
@@ -158,7 +158,7 @@ jobs:
             latest=${{ startsWith(github.ref, 'refs/tags/') }}
           tags: |
             type=schedule,pattern=nightly
-            type=ref,event=branch,enable=${{ github.event_name != 'schedule' }}
+            type=ref,event=branch,enable=${{ github.event_name != 'schedule' }},pattern=nightly
             type=ref,event=tag
 
       -

--- a/README.md
+++ b/README.md
@@ -200,12 +200,11 @@ Release notes will always contain full details of changes in the container, incl
 
 | tag                 | description
 |---------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
-| `latest`            | Always latest release                                                                                                                      |
+| `latest`            | Always the latest release                                                                                                                  |
 | `2022.04.0`         | Date-based release                                                                                                                         |
 | `2022.04.1`         | Second release in a given month                                                                                                            |
-| `development`               | Similar to `latest`, but for the development branch (pushed occasionally)                                                                  |
 | `*beta`             | Early beta releases of upcoming versions - here be dragons                                                                                 |
-| `nightly`           | Like `development` but pushed every night and pulls from the latest `development` branches of the core Pi-hole components (Pi-hole, web, FTL)      |
+| `nightly`           | Built and pushed whenever there are changes on the `development` branch and additionally produced by the scheduled nightly job. These are the most experimental development images and may change frequently |
 
 ## Upgrading, Persistence, and Customizations
 


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

This PR does two things:
 - Drops the `development` tag. After thinking about it a lot, the `development` tag is next to pointless. And does not build when we end up in situations where the core/web/FTL code has changed in structure between their own master and dev branches. (See https://github.com/pi-hole/docker-pi-hole/pull/1905)
 - Reduces reuse of exact steps the build YAML by utilising YAML anchors, making it easier to maintain, and to reduce the possibility of error when updating two otherwise identical sections.


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_