### PR TITLE
Increase default FTL Startup wait time to 30 seconds

### DIFF
--- a/src/start.sh
+++ b/src/start.sh
@@ -75,9 +75,12 @@ start() {
         sleep 0.5
     done
 
-    # Wait until the FTL log contains the "FTL started" message before continuing, timeout after 10 seconds
+    # Set FTL startup timeout from environment variable, default to 30 seconds
+    local FTL_START_TIMEOUT="${FTL_START_TIMEOUT:-30}"
+
+    # Wait until the FTL log contains the "FTL started" message before continuing
     # exit if we do not find it
-    pihole-FTL wait-for '########## FTL started' /var/log/pihole/FTL.log 10 0 > /dev/null
+    pihole-FTL wait-for '########## FTL started' /var/log/pihole/FTL.log "${FTL_START_TIMEOUT}" 0 > /dev/null
     if [ $? -ne 0 ]; then
         echo "  [✗] FTL did not start - stopping container"
         exit 1


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

2025.10.0 introduced a change whereby we exit the container if FTL has not started up within 10 seconds. It seems that this may be a little too optimistic. See https://github.com/pi-hole/docker-pi-hole/issues/1918

This PR increases the default timeout to 30 seconds, which should surely be enough... but if it isn't, we also introduce an environment variable named FTL_START_TIMEOUT for the user to set the value to their liking, depending on their system behaviour.

An example of the container exit message shown below, with FTL_START_TIMEOUT set to 0 seconds to demonstrate behaviour

<img width="1171" height="241" alt="image" src="https://github.com/user-attachments/assets/3135634f-502b-4a74-82a9-735cd9b7e485" />



---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_