### PR TITLE
Don't hardcode FTL log file

### DIFF
--- a/src/start.sh
+++ b/src/start.sh
@@ -70,8 +70,11 @@ start() {
     # We need the PID of the capsh process so that we can wait for it to finish
     CAPSH_PID=$!
 
+    # Get the FTL log file path from the config
+    FTLlogFile=$(getFTLConfigValue files.log.ftl)
+
     # Wait until the log file exists before continuing
-    while [ ! -f /var/log/pihole/FTL.log ]; do
+    while [ ! -f "${FTLlogFile}" ]; do
         sleep 0.5
     done
 
@@ -80,7 +83,7 @@ start() {
 
     # Wait until the FTL log contains the "FTL started" message before continuing
     # exit if we do not find it
-    pihole-FTL wait-for '########## FTL started' /var/log/pihole/FTL.log "${FTL_START_TIMEOUT}" 0 > /dev/null
+    pihole-FTL wait-for '########## FTL started' "${FTLlogFile}" "${FTL_START_TIMEOUT}" 0 > /dev/null
     if [ $? -ne 0 ]; then
         echo "  [✗] FTL did not start within ${FTL_START_TIMEOUT} seconds - stopping container"
         echo "  [i] If this continues to happen, consider increasing the timeout by setting the FTL_START_TIMEOUT environment variable to a higher value (in seconds)."
@@ -97,9 +100,9 @@ start() {
     if [ "${TAIL_FTL_LOG:-1}" -eq 1 ]; then
         # Start tailing the FTL log from the most recent "FTL Started" message
         # Get the line number
-        startFrom=$(grep -n '########## FTL started' /var/log/pihole/FTL.log | tail -1 | cut -d: -f1)
+        startFrom=$(grep -n '########## FTL started' "${FTLlogFile}" | tail -1 | cut -d: -f1)
         # Start the tail from the line number and background it
-        tail --follow=name -n +"${startFrom}" /var/log/pihole/FTL.log &
+        tail --follow=name -n +"${startFrom}" "${FTLlogFile}" &
     else
         echo "  [i] FTL log output is disabled. Remove the Environment variable TAIL_FTL_LOG, or set it to 1 to enable FTL log output."
     fi


### PR DESCRIPTION
Users might have changed the location of `FTL.log` **inside** the container. Currently, this would prevent container startup.

https://github.com/pi-hole/docker-pi-hole/issues/1918#issuecomment-3448414421