### PR TITLE
Don't use hard-coded FTL.log path

### DIFF
--- a/src/start.sh
+++ b/src/start.sh
@@ -70,13 +70,16 @@ start() {
     # We need the PID of the capsh process so that we can wait for it to finish
     CAPSH_PID=$!
 
+    # Get the FTL log file path from the config
+    FTLlogFile=$(getFTLConfigValue files.log.ftl)
+
     # Wait until the log file exists before continuing
-    while [ ! -f /var/log/pihole/FTL.log ]; do
+    while [ ! -f "${FTLlogFile}" ]; do
         sleep 0.5
     done
 
     #  Wait until the FTL log contains the "FTL started" message before continuing
-    while ! grep -q '########## FTL started' /var/log/pihole/FTL.log; do
+    while ! grep -q '########## FTL started' "${FTLlogFile}"; do
         sleep 0.5
     done
 


### PR DESCRIPTION
Users might have changed the location of `FTL.log` **inside** the container. Currently, this would prevent container startup.

https://github.com/pi-hole/docker-pi-hole/issues/1918#issuecomment-3448414421