### PR TITLE
Start using commented tags for editorconfig-checker

### DIFF
--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -12,7 +12,7 @@ jobs:
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
     - name: Get editorconfig-checker
-      uses: editorconfig-checker/action-editorconfig-checker@4b6cd6190d435e7e084fb35e36a096e98506f7b9 # tag v2. is really out of date
+      uses: editorconfig-checker/action-editorconfig-checker@4b6cd6190d435e7e084fb35e36a096e98506f7b9 #v2.1.0
 
     - name: Run editorconfig-checker
       run: editorconfig-checker


### PR DESCRIPTION
They just released https://github.com/editorconfig-checker/action-editorconfig-checker/releases/tag/v2.1.0 so we can use that new tag for dependabot.