### PR TITLE
Fix build status badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Docker Pi-hole
 
-[![Build Status](https://github.com/pi-hole/docker-pi-hole/workflows/Test%20&%20Build/badge.svg)](https://github.com/pi-hole/docker-pi-hole/actions?query=workflow%3A%22Test+%26+Build%22) [![Docker Stars](https://img.shields.io/docker/stars/pihole/pihole.svg?maxAge=604800)](https://store.docker.com/community/images/pihole/pihole) [![Docker Pulls](https://img.shields.io/docker/pulls/pihole/pihole.svg?maxAge=604800)](https://store.docker.com/community/images/pihole/pihole)
+[![Build Status](https://github.com/pi-hole/docker-pi-hole/workflows/Build%20Image%20and%20Test/badge.svg)](https://github.com/pi-hole/docker-pi-hole/actions?query=workflow%3A%22Build+Image+and+Test%22) [![Docker Stars](https://img.shields.io/docker/stars/pihole/pihole.svg?maxAge=604800)](https://store.docker.com/community/images/pihole/pihole) [![Docker Pulls](https://img.shields.io/docker/pulls/pihole/pihole.svg?maxAge=604800)](https://store.docker.com/community/images/pihole/pihole)
 
 <div align="center">
   <a href="https://pi-hole.net/">


### PR DESCRIPTION
## Description
Fixes the broken build status badge. Was pointed at a workflow that was either removed or renamed.

## Motivation and Context
Saw the broken link and wanted to fix it

## How Has This Been Tested?
Fixed the link and clicked through to the actions page to ensure it worked

## Types of changes
Updates the query parameter in the URL

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
