### PR TITLE
Improve FTL startup detection and log tailing

### DIFF
--- a/src/start.sh
+++ b/src/start.sh
@@ -79,7 +79,7 @@ start() {
 
     # Wait for FTL to start by monitoring the FTL log file for the "FTL started" line
     if ! timeout 30 tail -F -c +$((startFrom + 1)) -- "${FTLlogFile}" | grep -q '########## FTL started'; then
-        echo "  [!] ERROR: FTL failed to start within 30 seconds, stopping container"
+        echo "  [!] ERROR: Did not find 'FTL started' message in ${FTLlogFile} in 30 seconds, stopping container"
         exit 1
     fi
 


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

This PR take a little logic from https://github.com/pi-hole/docker-pi-hole/pull/1932, and a little from https://github.com/pi-hole/docker-pi-hole/pull/1934

Both are good ideas, but I want to combine and tweak them a little. For example, I do not want to use the `pihole-FTL wait-for` command, as it does not _quite_ suit the purpose we are looking for, but I _do_ want to exit the container if FTL has not started within 30 seconds - else it will just hang.

I also like the idea of reading the FTL log filesize on container start, and then basing all interaction with the log file from that point onwards.



---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_