### PR TITLE
Set DNS listening mode to 'ALL' in docker-compose.yml example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ services:
       TZ: 'Europe/London'
       # Set a password to access the web interface. Not setting one will result in a random password being assigned
       FTLCONF_webserver_api_password: 'correct horse battery staple'
-      # If using Docker's default `bridge` network setting the dns listening mode should be set to 'all'
-      FTLCONF_dns_listeningMode: 'all'
+      # If using Docker's default `bridge` network setting the dns listening mode should be set to 'ALL'
+      FTLCONF_dns_listeningMode: 'ALL'
     # Volumes store your data between container upgrades
     volumes:
       # For persisting Pi-hole's databases and common configuration file


### PR DESCRIPTION
## Description

The code snippet in README.md contains this environment variable:

FTLCONF_dns_listeningMode: 'all'

This was changed to 

FTLCONF_dns_listeningMode: 'ALL'

to reflect the [current documentation](https://docs.pi-hole.net/ftldns/configfile/#listeningmode).

## Motivation and Context
When using lower case 'all', my pi-hole still only picked up local dns requests.
Changing it to 'ALL' made it accept dns requests from other clients on the network too.

## How Has This Been Tested?
I made requests from different clients on the network. At first, they were not shown in the query log and not resolved by pi-hole. After the change, all the requests appeared in the query log and were resolved.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
