### PR TITLE
Add instructions for excluding Pi-hole from Watchtower updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ We have noticed that a lot of people use Watchtower to keep their Pi-hole contai
   - If you care about your data (logs/customizations), make sure you have it volume-mapped or it will be deleted in this step.
 - Recreate the container using the new image.
 
-If you wish to exclude the Pi-hole container from Watchtower's auto-update system take a look at [Full Exclude](https://containrrr.dev/watchtower/container-selection/#full_exclude) in Watchtower's docs.
+To exclude the Pi-hole container from Watchtower's auto-update system take a look at [Full Exclude](https://containrrr.dev/watchtower/container-selection/#full_exclude) in Watchtower's docs.
 
 Pi-hole is an integral part of your network, don't let it fall over because of an unattended update in the middle of the night.
 


### PR DESCRIPTION
Added instructions to exclude Pi-hole container from Watchtower's  auto-update system.



<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Modified the README file in order to add the instructions to fully exclude the Pi-hole container from Watchtower.
The instructions can be find in Watchtower's official documentation [Full exclude section](https://containrrr.dev/watchtower/container-selection/#full_exclude)
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change avoids a new Pi-hole user to go back on Watchtower's documentation to find how to exclude some container from the auto-update system. 
The simple pice of setting that needs to be added on the Docker-compose is now available directly in the Pi-hole README
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
