### PR TITLE
Pin base image by sha to catch silent rebuilds

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 ARG FTL_SOURCE=remote
 # Pull Stable images
-FROM alpine:3.23 AS base
+FROM alpine:3.23.0@sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375 AS base
 
 ARG TARGETPLATFORM
 ARG WEB_BRANCH="development"


### PR DESCRIPTION
Pin the used Alpine base image not only by semVer but also by SHA digest. This allows to catch silent rebuilds. Good read at https://www.bretfisher.com/silent-rebuilds/