### PR TITLE
Set fixed buildx version to mitigate issues with buildx version 0.31.1

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -95,6 +95,10 @@ jobs:
       - &setup-buildx
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f #v3.12.0
+        with:
+          # Buildx version 0.31.1 broke our publish workflow, this need to be revised when 0.32.0 is released
+          # https://github.com/docker/buildx/releases/tag/v0.31.1
+          version: v0.31.0
 
       - name: Build container and push by digest
         id: build


### PR DESCRIPTION
Since 6th of feb our publish workflow failed without us having changed anything. Deep inspection revealed, that the buildx version installed by `docker/setup-buildx-action` increased from `v0.31.0` to `v0.31.1`. The new version made changes to the command we use `buildx imagetools create`. (See https://github.com/docker/buildx/releases/tag/v0.31.1).

This PR set the installed version to a fixed version  `v0.31.0` to hopefully mitigate the issue. This change need to be reverted in the future when things have been sorted at `buildx` side.