### PR TITLE
Replace content of Contributing.md with link to our documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,5 @@
-# Pull Request Guidelines
+# Contributors Guide
 
-Please review the following before opening a pull request (PR) to help your PR go smoothly:
+Please read and understand the contribution guide before creating an issue or pull request.
 
-* Code changes go to the `development` branch first
-  * To ensure proper testing and quality control, target any code change pull requests against `development` branch.
-
-* Make sure the tests pass
-  * Take a look at [TESTING.md](test/TESTING.md) to see how to run tests locally so you do not have to push all your code to a PR and have GitHub Actions run it.
-  * Your tests will probably run faster locally and you get a faster feedback loop.
+The guide can be found here: [https://docs.pi-hole.net/guides/github/contributing/](https://docs.pi-hole.net/guides/github/contributing/)


### PR DESCRIPTION
As the title says. 

**Cave: targeting `master` on purpore**