### PR TITLE
Make crond and cron job output visible in "docker log"

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -98,6 +98,7 @@ RUN cd /etc/.pihole && \
     echo "${PIHOLE_DOCKER_TAG}" > /pihole.docker.tag
 
 COPY --chmod=0755 bash_functions.sh /usr/bin/bash_functions.sh
+COPY --chmod=0755 prefix-time.sh /usr/bin/prefix-time.sh
 COPY --chmod=0755 start.sh /usr/bin/start.sh
 
 EXPOSE 53 53/udp

--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -89,7 +89,9 @@ start_cron() {
         echo "  [!] Failed to install crontab - scheduled tasks (gravity, update checker) will not run"
     fi
 
-    /usr/sbin/crond
+    # Run crond in foreground, prefix each line from STDIN/STDOUT with the current date/time/timezone and
+    # write to PID 1 STDOUT (docker log)
+    { /usr/sbin/crond -f -d 6 |& prefix-time.sh; } &
     echo ""
 }
 

--- a/src/prefix-time.sh
+++ b/src/prefix-time.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Prefix each line from STDIN with the current date/time/timezone and write to PID 1 STDOUT (docker log)
+while IFS= read -r line; do
+    printf '%s %s\n' "$(date '+%F %T.%3N %Z')" "$line" >>/proc/1/fd/1
+done


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Currently `crond` runs silently in the background. There is no indication, when jobs are running or if the jobs produce any output (in case of failures).

This PR solves this by running `crond` with increased log level (6). It also prefixes each line with the current date/time/timezone to align with FTL's output.

The result in "docker log" looks like this:

```
2026-05-16 13:37:38 CEST crond: crond (busybox 1.37.0) started, log level 6
[..]
2026-05-16 13:37:38.899 CEST [52/T59] INFO: Web server ports:
2026-05-16 13:37:38.899 CEST [52/T59] INFO:   - 0.0.0.0:80 (HTTP, IPv4, optional, OK)
2026-05-16 13:37:38.899 CEST [52/T59] INFO:   - 0.0.0.0:443 (HTTPS, IPv4, optional, OK)
2026-05-16 13:37:38.899 CEST [52/T59] INFO:   - [::]:80 (HTTP, IPv6, optional, OK)
2026-05-16 13:37:38.899 CEST [52/T59] INFO:   - [::]:443 (HTTPS, IPv6, optional, OK)
2026-05-16 13:37:38.900 CEST [52/T55] INFO: Compiled 0 allow and 0 deny regex for 0 client in 0.0 msec
2026-05-16 13:37:53.067 CEST [52/T54] INFO: Received 8/8 valid NTP replies from pool.ntp.org
2026-05-16 13:37:53.068 CEST [52/T54] INFO: NTP time offset: 1.463992e+00 ms (excluded 1 outliers)
2026-05-16 13:37:53.068 CEST [52/T54] INFO: NTP round-trip delay: 1.893868e+01 ms (excluded 1 outliers)
2026-05-16 13:37:53.068 CEST [52/T148] INFO: NTP server listening on 0.0.0.0:123 (IPv4)
2026-05-16 13:37:53.068 CEST [52/T149] INFO: NTP server listening on :::123 (IPv6)
[..]
2026-05-16 13:38:00 CEST crond: USER root pid 150 cmd PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole updatechecker
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Yes, with a local build to produce the output above.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
