### PR TITLE
Use structed json logging

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -18,7 +18,7 @@ ARG PIHOLE_UID=1000
 ARG PIHOLE_GID=1000
 
 ENV DNSMASQ_USER=pihole
-ENV FTL_CMD=no-daemon
+ENV FTL_CMD="no-daemon --log-json"
 
 RUN apk add --no-cache \
     bash \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -98,7 +98,6 @@ RUN cd /etc/.pihole && \
     echo "${PIHOLE_DOCKER_TAG}" > /pihole.docker.tag
 
 COPY --chmod=0755 bash_functions.sh /usr/bin/bash_functions.sh
-COPY --chmod=0755 prefix-time.sh /usr/bin/prefix-time.sh
 COPY --chmod=0755 start.sh /usr/bin/start.sh
 
 EXPOSE 53 53/udp

--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -28,22 +28,55 @@ setFTLConfigValue() {
     pihole-FTL --config "${1}" "${2}" >/dev/null
 }
 
+__timestamp(){
+  date "+%Y%m%dT%H%M%S"
+}
+
+__log(){
+  local level="$1"
+  local service="$2"
+  local msg="$3"
+
+  # Check if msg is valid JSON - if so, use --argjson to avoid escaping
+  if echo "$msg" | jq empty 2>/dev/null; then
+    echo '{}' | \
+    jq  --monochrome-output \
+        --compact-output \
+        --raw-output \
+        --arg timestamp "$(__timestamp)" \
+        --arg level "$level" \
+        --arg service "$service" \
+        --argjson msg "$msg" \
+        '.timestamp=$timestamp|.log_level=$level|.service=$service|.message=$msg'
+  else
+    echo '{}' | \
+    jq  --monochrome-output \
+        --compact-output \
+        --raw-output \
+        --arg timestamp "$(__timestamp)" \
+        --arg level "$level" \
+        --arg service "$service" \
+        --arg msg "$msg" \
+        '.timestamp=$timestamp|.log_level=$level|.service=$service|.message=$msg'
+  fi
+}
+
 set_uid_gid() {
 
-    echo "  [i] Setting up user & group for the pihole user"
+    __log "INFO" "pihole-docker" "Setting up user & group for the pihole user"
 
     currentUid=$(id -u pihole)
 
     # If PIHOLE_UID is set, modify the pihole group's id to match
     if [ -n "${PIHOLE_UID}" ]; then
         if [[ ${currentUid} -ne ${PIHOLE_UID} ]]; then
-            echo "  [i] Changing ID for user: pihole (${currentUid} => ${PIHOLE_UID})"
+            __log "INFO" "pihole-docker" "Changing ID for user: pihole (${currentUid} => ${PIHOLE_UID})"
             usermod -o -u "${PIHOLE_UID}" pihole
         else
-            echo "  [i] ID for user pihole is already ${PIHOLE_UID}, no need to change"
+            __log "INFO" "pihole-docker" "ID for user pihole is already ${PIHOLE_UID}, no need to change"
         fi
     else
-        echo "  [i] PIHOLE_UID not set in environment, using default (${currentUid})"
+        __log "INFO" "pihole-docker" "PIHOLE_UID not set in environment, using default (${currentUid})"
     fi
 
     currentGid=$(id -g pihole)
@@ -51,42 +84,40 @@ set_uid_gid() {
     # If PIHOLE_GID is set, modify the pihole group's id to match
     if [ -n "${PIHOLE_GID}" ]; then
         if [[ ${currentGid} -ne ${PIHOLE_GID} ]]; then
-            echo "  [i] Changing ID for group: pihole (${currentGid} => ${PIHOLE_GID})"
+            __log "INFO" "pihole-docker" "Changing ID for group: pihole (${currentGid} => ${PIHOLE_GID})"
             groupmod -o -g "${PIHOLE_GID}" pihole
         else
-            echo "  [i] ID for group pihole is already ${PIHOLE_GID}, no need to change"
+            __log "INFO" "pihole-docker" "ID for group pihole is already ${PIHOLE_GID}, no need to change"
         fi
     else
-        echo "  [i] PIHOLE_GID not set in environment, using default (${currentGid})"
+        __log "INFO" "pihole-docker" "PIHOLE_GID not set in environment, using default (${currentGid})"
     fi
-    echo ""
 }
 
 install_additional_packages() {
     if [ -n "${ADDITIONAL_PACKAGES}" ]; then
-        echo "  [i] Additional packages requested: ${ADDITIONAL_PACKAGES}"
-        echo "  [i] Fetching APK repository metadata."
+        __log "INFO" "pihole-docker" "Additional packages requested: ${ADDITIONAL_PACKAGES}"
+        __log "INFO" "pihole-docker" "Fetching APK repository metadata."
         if ! apk update; then
-            echo "  [i] Failed to fetch APK repository metadata."
+            __log "ERROR" "pihole-docker" "Failed to fetch APK repository metadata."
         else
-            echo "  [i] Installing additional packages: ${ADDITIONAL_PACKAGES}."
+            __log "INFO" "pihole-docker" "Installing additional packages: ${ADDITIONAL_PACKAGES}."
             # shellcheck disable=SC2086
             if ! apk add --no-cache ${ADDITIONAL_PACKAGES}; then
-                echo "  [i] Failed to install additional packages."
+                __log "ERROR" "pihole-docker" "Failed to install additional packages."
             fi
         fi
-        echo ""
     fi
 }
 
 start_cron() {
-    echo "  [i] Starting crond for scheduled scripts. Randomizing times for gravity and update checker"
+    __log "INFO" "pihole-docker" "Starting crond for scheduled scripts. Randomizing times for gravity and update checker"
     # Randomize gravity update time
     sed -i "s/59 1 /$((1 + RANDOM % 58)) $((3 + RANDOM % 2))/" /crontab.txt
     # Randomize update checker time
     sed -i "s/59 17/$((1 + RANDOM % 58)) $((12 + RANDOM % 8))/" /crontab.txt
     if ! /usr/bin/crontab /crontab.txt; then
-        echo "  [!] Failed to install crontab - scheduled tasks (gravity, update checker) will not run"
+        __log "ERROR" "pihole-docker" "Failed to install crontab - scheduled tasks (gravity, update checker) will not run"
     fi
 
     # Run crond in foreground, prefix each line from STDIN/STDOUT with the current date/time/timezone and
@@ -99,33 +130,31 @@ install_logrotate() {
     # Install the logrotate config file - this is done already in Dockerfile
     # but if a user has mounted a volume over /etc/pihole, it will have been lost
     # pihole-FTL-prestart.sh will set the ownership of the file to root:root
-    echo "  [i] Ensuring logrotate script exists in /etc/pihole"
+    __log "INFO" "pihole-docker" "Ensuring logrotate script exists in /etc/pihole"
     install -Dm644 -t /etc/pihole /etc/.pihole/advanced/Templates/logrotate
-    echo ""
 }
 
 migrate_gravity() {
-    echo "  [i] Gravity migration checks"
+    __log "INFO" "pihole-docker" "Gravity migration checks"
     gravityDBfile=$(getFTLConfigValue files.gravity)
 
     if [[ ! -f /etc/pihole/adlists.list ]]; then
-        echo "  [i] No adlist file found, creating one with a default blocklist"
+        __log "INFO" "pihole-docker" "No adlist file found, creating one with a default blocklist"
         echo "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts" >/etc/pihole/adlists.list
     fi
 
     if [ ! -f "${gravityDBfile}" ]; then
-        echo "  [i] ${gravityDBfile} does not exist (Likely due to a fresh volume). This is a required file for Pi-hole to operate."
-        echo "  [i] Gravity will now be run to create the database"
+        __log "INFO" "pihole-docker" "${gravityDBfile} does not exist (Likely due to a fresh volume). This is a required file for Pi-hole to operate."
+        __log "INFO" "pihole-docker" "Gravity will now be run to create the database"
         pihole -g
     else
-        echo "  [i] Existing gravity database found - schema will be upgraded if necessary"
+        __log "INFO" "pihole-docker" "Existing gravity database found - schema will be upgraded if necessary"
         # source the migration script and run the upgrade function
         source /etc/.pihole/advanced/Scripts/database_migration/gravity-db.sh
         local upgradeOutput
         upgradeOutput=$(upgrade_gravityDB "${gravityDBfile}" "/etc/pihole")
-        printf "%b" "${upgradeOutput}\\n" | sed 's/^/     /'
+        __log "INFO" "pihole-docker" "Gravity DB migration output: ${upgradeOutput}"
     fi
-    echo ""
 }
 
 # shellcheck disable=SC2034
@@ -144,7 +173,7 @@ ftl_config() {
 
     # If getFTLConfigValue "dns.upstreams" returns [], default to Google's DNS server
     if [[ $(getFTLConfigValue "dns.upstreams") == "[]" ]]; then
-        echo "  [i] No DNS upstream set in environment or config file, defaulting to Google DNS"
+        __log "INFO" "pihole-docker" "No DNS upstream set in environment or config file, defaulting to Google DNS"
         setFTLConfigValue "dns.upstreams" "[\"8.8.8.8\", \"8.8.4.4\"]"
     fi
 
@@ -156,7 +185,7 @@ migrate_v5_configs() {
     # During migration, their content is copied into the new single source of
     # truth file /etc/pihole/pihole.toml and the old files are moved away to
     # avoid conflicts with other services on this system
-    echo "  [i] Migrating dnsmasq configuration files"
+    __log "INFO" "pihole-docker" "Migrating dnsmasq configuration files"
     V6_CONF_MIGRATION_DIR="/etc/pihole/migration_backup_v6"
     # Create target directory and make it owned by pihole:pihole
     mkdir -p "${V6_CONF_MIGRATION_DIR}"
@@ -171,7 +200,6 @@ migrate_v5_configs() {
 
     mv /etc/dnsmasq.d/0{1,2,4,5}-pihole*.conf "${V6_CONF_MIGRATION_DIR}/" 2>/dev/null || true
     mv /etc/dnsmasq.d/06-rfc6761.conf "${V6_CONF_MIGRATION_DIR}/" 2>/dev/null || true
-    echo ""
 
     # Finally, after everything is in place, we can create the new config file
     # /etc/pihole/pihole.toml
@@ -186,13 +214,11 @@ migrate_v5_configs() {
     # We suppress the message about environment variables as these will be set on FTL's first real start
     printf "%b" "${FTLoutput}\\n" | sed 's/^/      /' | sed 's/      Migrating config to Pi-hole v6.0 format/  [i] Migrating config to Pi-hole v6.0 format/' | sed 's/- 0 entries are forced through environment//'
 
-    # Print a blank line for separation
-    echo ""
 }
 
 setup_web_password() {
     if [ -z "${FTLCONF_webserver_api_password+x}" ] && [ -n "${WEBPASSWORD_FILE}" ] && [ -r "/run/secrets/${WEBPASSWORD_FILE}" ]; then
-        echo "  [i] Setting FTLCONF_webserver_api_password from file"
+        __log "INFO" "pihole-docker" "Setting FTLCONF_webserver_api_password from file"
         FTLCONF_webserver_api_password=$(<"/run/secrets/${WEBPASSWORD_FILE}")
         export FTLCONF_webserver_api_password
     fi
@@ -201,13 +227,13 @@ setup_web_password() {
     if [ -z "${FTLCONF_webserver_api_password+x}" ]; then
         # Is this already set to something other than blank (default) in FTL's config file? (maybe in a volume mount)
         if [[ $(pihole-FTL --config webserver.api.pwhash) ]]; then
-            echo "  [i] Password already set in config file"
+            __log "INFO" "pihole-docker" "Password already set in config file"
             return
         else
             # If we are here, the password is set in neither the environment nor the config file
             # We will generate a random password.
             RANDOMPASSWORD=$(tr -dc _A-Z-a-z-0-9 </dev/urandom | head -c 8)
-            echo "  [i] No password set in environment or config file, assigning random password: $RANDOMPASSWORD"
+            __log "INFO" "pihole-docker" "No password set in environment or config file, assigning random password: $RANDOMPASSWORD"
 
             # Explicitly turn off bash printing when working with secrets
             { set +x; } 2>/dev/null
@@ -221,7 +247,7 @@ setup_web_password() {
             fi
         fi
     else
-        echo "  [i] Assigning password defined by Environment Variable"
+        __log "INFO" "pihole-docker" "Assigning password defined by Environment Variable"
     fi
 }
 
@@ -229,7 +255,7 @@ fix_capabilities() {
     # Testing on Docker 20.10.14 with no caps set shows the following caps available to the container:
     # Current: cap_chown,cap_dac_override,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,cap_net_bind_service,cap_net_raw,cap_sys_chroot,cap_mknod,cap_audit_write,cap_setfcap=ep
     # FTL can also use CAP_NET_ADMIN and CAP_SYS_NICE. If we try to set them when they haven't been explicitly enabled, FTL will not start. Test for them first:
-    echo "  [i] Setting capabilities on pihole-FTL where possible"
+    __log "INFO" "pihole-docker" "Setting capabilities on pihole-FTL where possible"
     capsh --has-p=cap_chown 2>/dev/null && CAP_STR+=',CAP_CHOWN'
     capsh --has-p=cap_net_bind_service 2>/dev/null && CAP_STR+=',CAP_NET_BIND_SERVICE'
     capsh --has-p=cap_net_raw 2>/dev/null && CAP_STR+=',CAP_NET_RAW'
@@ -239,30 +265,28 @@ fix_capabilities() {
 
     if [[ ${CAP_STR} ]]; then
         # We have the (some of) the above caps available to us - apply them to pihole-FTL
-        echo "  [i] Applying the following caps to pihole-FTL:"
         IFS=',' read -ra CAPS <<<"${CAP_STR:1}"
-        for i in "${CAPS[@]}"; do
-            echo "        * ${i}"
-        done
+        # Build JSON array from capabilities
+        CAPS_JSON=$(printf '%s\n' "${CAPS[@]}" | jq -R . | jq -s '{"applied_capabilities": .}')
+        __log "INFO" "pihole-docker" "$CAPS_JSON"
 
         setcap "${CAP_STR:1}"+ep "$(which pihole-FTL)" || ret=$?
 
         if [[ $DHCP_READY == false ]] && [[ $FTLCONF_dhcp_active == true ]]; then
             # DHCP is requested but NET_ADMIN is not available.
-            echo "ERROR: DHCP requested but NET_ADMIN is not available. DHCP will not be started."
-            echo "      Please add cap_net_admin to the container's capabilities or disable DHCP."
+            __log "ERROR" "pihole-docker" "DHCP requested but NET_ADMIN is not available. DHCP will not be started."
+            __log "INFO" "pihole-docker" "      Please add cap_net_admin to the container's capabilities or disable DHCP."
             setFTLConfigValue dhcp.active false
         fi
 
         if [[ $ret -ne 0 && "${DNSMASQ_USER:-pihole}" != "root" ]]; then
-            echo "  [!] ERROR: Unable to set capabilities for pihole-FTL. Cannot run as non-root."
-            echo "            If you are seeing this error, please set the environment variable 'DNSMASQ_USER' to the value 'root'"
+            __log "ERROR" "pihole-docker" "Unable to set capabilities for pihole-FTL. Cannot run as non-root."
+            __log "ERROR" "pihole-docker" "If you are seeing this error, please set the environment variable 'DNSMASQ_USER' to the value 'root'"
             exit 1
         fi
     else
-        echo "  [!] ERROR: Unable to set capabilities for pihole-FTL."
-        echo "            Please ensure that the container has the required capabilities."
+        __log "ERROR" "pihole-docker" "Unable to set capabilities for pihole-FTL."
+        __log "ERROR" "pihole-docker" "Please ensure that the container has the required capabilities."
         exit 1
     fi
-    echo ""
 }

--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -120,9 +120,10 @@ start_cron() {
         __log "ERROR" "pihole-docker" "Failed to install crontab - scheduled tasks (gravity, update checker) will not run"
     fi
 
-    # Run crond in foreground, prefix each line from STDIN/STDOUT with the current date/time/timezone and
-    # write to PID 1 STDOUT (docker log)
-    { /usr/sbin/crond -f -d 6 |& prefix-time.sh; } &
+    # Run crond in foreground and emit each line as structured JSON to container stdout
+    { /usr/sbin/crond -f -d 6 |& while IFS= read -r line; do
+        __log "INFO" "crond" "$line"
+    done; } &
     echo ""
 }
 

--- a/src/bash_functions.sh
+++ b/src/bash_functions.sh
@@ -29,7 +29,7 @@ setFTLConfigValue() {
 }
 
 __timestamp(){
-  date "+%Y%m%dT%H%M%S"
+  date '+%F %T.%3N %Z'
 }
 
 __log(){

--- a/src/prefix-time.sh
+++ b/src/prefix-time.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# Prefix each line from STDIN with the current date/time/timezone and write to PID 1 STDOUT (docker log)
-while IFS= read -r line; do
-    printf '%s %s\n' "$(date '+%F %T.%3N %Z')" "$line" >>/proc/1/fd/1
-done

--- a/src/start.sh
+++ b/src/start.sh
@@ -66,11 +66,10 @@ start() {
 
     __log "INFO" "pihole-docker" "Starting pihole-FTL as user ${DNSMASQ_USER}"
 
-    capsh --user="${DNSMASQ_USER}" --keep=1 -- -c "/usr/bin/pihole-FTL $FTL_CMD >/dev/null" &
+    capsh --user="${DNSMASQ_USER}" --keep=1 -- -c "/usr/bin/pihole-FTL $FTL_CMD" &
     # Notes on above:
     # - DNSMASQ_USER default of pihole is in Dockerfile & can be overwritten by runtime container env
-    # - /var/log/pihole/pihole*.log has FTL's output that no-daemon would normally print in FG too
-    #   prevent duplicating it in docker logs by sending to dev null
+    # - "--log-json" already writes full structured JSON, we can capture it directly
 
     # We need the PID of the capsh process so that we can wait for it to finish
     CAPSH_PID=$!
@@ -91,13 +90,6 @@ start() {
       ftl: .version.ftl.local | {version, branch, hash, date}
     }')
     __log "INFO" "pihole-docker" "$versionJson"
-
-    if [ "${TAIL_FTL_LOG:-1}" -eq 1 ]; then
-        # Start tailing the FTL log file from the EOF position we recorded on container start
-        tail -F -c +$((startFrom + 1)) -- "${FTLlogFile}" &
-    else
-        __log "INFO" "pihole-docker" "FTL log output is disabled. Remove the Environment variable TAIL_FTL_LOG, or set it to 1 to enable FTL log output."
-    fi
 
     # Wait for the capsh process (which spawned FTL) to finish
     wait $CAPSH_PID

--- a/src/start.sh
+++ b/src/start.sh
@@ -23,8 +23,7 @@ start() {
     # If the file /etc/pihole/setupVars.conf exists, but /etc/pihole/pihole.toml does not, then we are migrating v5->v6
     # FTL Will handle the migration of the config files
     if [[ -f /etc/pihole/setupVars.conf && ! -f /etc/pihole/pihole.toml ]]; then
-        echo "  [i] v5 files detected that have not yet been migrated to v6"
-        echo ""
+        __log "INFO" "pihole-docker" "v5 files detected that have not yet been migrated to v6"
         migrate_v5_configs
     fi
 
@@ -36,7 +35,7 @@ start() {
     set_uid_gid
 
     # Configure FTL with any environment variables if needed
-    echo "  [i] Starting FTL configuration"
+    __log "INFO" "pihole-docker" "Starting FTL configuration"
     ftl_config
 
     # Install additional packages inside the container if requested
@@ -51,7 +50,7 @@ start() {
     #migrate Gravity Database if needed:
     migrate_gravity
 
-    echo "  [i] pihole-FTL pre-start checks"
+    __log "INFO" "pihole-docker" "pihole-FTL pre-start checks"
     # Run the post stop script to cleanup any remaining artifacts from a previous run
     sh /opt/pihole/pihole-FTL-poststop.sh
 
@@ -65,8 +64,7 @@ start() {
     local startFrom
     startFrom=$(stat -c%s "${FTLlogFile}")
 
-    echo "  [i] Starting pihole-FTL ($FTL_CMD) as ${DNSMASQ_USER}"
-    echo ""
+    __log "INFO" "pihole-docker" "Starting pihole-FTL as user ${DNSMASQ_USER}"
 
     capsh --user="${DNSMASQ_USER}" --keep=1 -- -c "/usr/bin/pihole-FTL $FTL_CMD >/dev/null" &
     # Notes on above:
@@ -79,22 +77,26 @@ start() {
 
     # Wait for FTL to start by monitoring the FTL log file for the "FTL started" line
     if ! timeout 30 tail -F -c +$((startFrom + 1)) -- "${FTLlogFile}" | grep -q '########## FTL started'; then
-        echo "  [!] ERROR: Did not find 'FTL started' message in ${FTLlogFile} in 30 seconds, stopping container"
+        __log "ERROR" "pihole-docker" "Did not find 'FTL started' message in ${FTLlogFile} in 30 seconds, stopping container"
         exit 1
     fi
 
     pihole updatechecker
-    local versionsOutput
-    versionsOutput=$(pihole -v)
-    echo "  [i] Version info:"
-    printf "%b" "${versionsOutput}\\n" | sed 's/^/      /'
-    echo ""
+
+    # Get version information from API endpoint
+    local versionJson
+    versionJson=$(pihole api info/version | jq -c '{
+      core: .version.core.local | {version, branch, hash},
+      web: .version.web.local | {version, branch, hash},
+      ftl: .version.ftl.local | {version, branch, hash, date}
+    }')
+    __log "INFO" "pihole-docker" "$versionJson"
 
     if [ "${TAIL_FTL_LOG:-1}" -eq 1 ]; then
         # Start tailing the FTL log file from the EOF position we recorded on container start
         tail -F -c +$((startFrom + 1)) -- "${FTLlogFile}" &
     else
-        echo "  [i] FTL log output is disabled. Remove the Environment variable TAIL_FTL_LOG, or set it to 1 to enable FTL log output."
+        __log "INFO" "pihole-docker" "FTL log output is disabled. Remove the Environment variable TAIL_FTL_LOG, or set it to 1 to enable FTL log output."
     fi
 
     # Wait for the capsh process (which spawned FTL) to finish
@@ -116,8 +118,8 @@ stop() {
     if [ -z "${FTL_EXIT_CODE}" ]; then
         TRAP_TRIGGERED=1
         echo ""
-        echo "  [i] Container stop requested..."
-        echo "  [i] pihole-FTL is running - Attempting to shut it down cleanly"
+        __log "INFO" "pihole-docker" "Container stop requested..."
+        __log "INFO" "pihole-docker" "pihole-FTL is running - Attempting to shut it down cleanly"
         echo ""
         killall --signal 15 pihole-FTL
 
@@ -135,12 +137,8 @@ stop() {
 
     sh /opt/pihole/pihole-FTL-poststop.sh
 
-    echo ""
-    echo "  [i] pihole-FTL exited with status $FTL_EXIT_CODE"
-    echo ""
-    echo "  [i] Container will now stop or restart depending on your restart policy"
-    echo "      https://docs.docker.com/engine/containers/start-containers-automatically/#use-a-restart-policy"
-    echo ""
+    __log "INFO" "pihole-docker" "pihole-FTL exited with status ${FTL_EXIT_CODE}"
+    __log "INFO" "pihole-docker" "Container will now stop or restart depending on your restart policy - https://docs.docker.com/engine/containers/start-containers-automatically/#use-a-restart-policy"
 
     exit "${FTL_EXIT_CODE}"
 

--- a/test/test_env_vars.bats
+++ b/test/test_env_vars.bats
@@ -11,8 +11,7 @@ setup_file() {
         -e FTLCONF_webserver_api_password=1234567890 \
         -e FTLCONF_webserver_port=8080 \
         -e FTLCONF_dns_upstreams="8.8.8.8;1.1.1.1" \
-        -e ADDITIONAL_PACKAGES=wget \
-        -e TAIL_FTL_LOG=0)
+        -e ADDITIONAL_PACKAGES=wget)
     wait_for_log "$CONTAINER" "FTL log output is disabled"
     export CONTAINER
 }
@@ -64,15 +63,4 @@ teardown_file() {
 @test "Web interface is accessible on custom port" {
     run docker exec "$CONTAINER" curl -sf http://localhost:8080/admin
     assert_success
-}
-
-# ---- TAIL_FTL_LOG disabled --------------------------------------------------
-
-@test "TAIL_FTL_LOG=0 suppresses FTL log output in docker logs" {
-    # TAIL_FTL_LOG defaults to 1 (enabled); the default container exercises that path.
-    # This test verifies the opt-out case.
-    run docker logs "$CONTAINER"
-    assert_success
-    assert_output --partial "FTL log output is disabled"
-    refute_output --partial "########## FTL started"
 }


### PR DESCRIPTION
State of the art logging for docker is structured json logging. This allows aggregation, analysis and filtering. Currently, we use plain shell output that is optimized for human consumption. This PR changes the output to structured `json` which can be easily parsed and consumed by other tools.

This kind of output allows separation of the logging of the processes running on the container simultaneously:  `start.sh`, `FTL`, `crond`,...

This is a draft. Before I go on and parse the FTL output (or maybe adjust this in FTL repo), I'd like to know the opinion of the other team members. Example output

```
pihole  | {"timestamp":"20260516T155604","log_level":"INFO","service":"pihole-docker","message":"Setting up user & group for the pihole user"}
pihole  | {"timestamp":"20260516T155604","log_level":"INFO","service":"pihole-docker","message":"PIHOLE_UID not set in environment, using default (1000)"}
pihole  | {"timestamp":"20260516T155604","log_level":"INFO","service":"pihole-docker","message":"PIHOLE_GID not set in environment, using default (1000)"}
pihole  | {"timestamp":"20260516T155604","log_level":"INFO","service":"pihole-docker","message":"Starting FTL configuration"}
pihole  | {"timestamp":"20260516T155604","log_level":"INFO","service":"pihole-docker","message":"Assigning password defined by Environment Variable"}
pihole  | {"timestamp":"20260516T155604","log_level":"INFO","service":"pihole-docker","message":"Starting crond for scheduled scripts. Randomizing times for gravity and update checker"}
pihole  | {"timestamp":"20260516T155604","log_level":"INFO","service":"pihole-docker","message":"Ensuring logrotate script exists in /etc/pihole"}
pihole  | {"timestamp":"20260516T155604","log_level":"INFO","service":"pihole-docker","message":"Gravity migration checks"}
pihole  | {"timestamp":"20260516T155604","log_level":"INFO","service":"pihole-docker","message":"Existing gravity database found - schema will be upgraded if necessary"}
pihole  | {"timestamp":"20260516T155604","log_level":"INFO","service":"pihole-docker","message":"Gravity DB migration output: "}
pihole  | {"timestamp":"20260516T155604","log_level":"INFO","service":"pihole-docker","message":"pihole-FTL pre-start checks"}
pihole  | {"timestamp":"20260516T155604","log_level":"INFO","service":"pihole-docker","message":"Setting capabilities on pihole-FTL where possible"}
pihole  | {"timestamp":"20260516T155604","log_level":"INFO","service":"pihole-docker","message":{"applied_capabilities":["CAP_CHOWN","CAP_NET_BIND_SERVICE","CAP_NET_RAW","CAP_SYS_TIME"]}}
pihole  | {"timestamp":"20260516T155604","log_level":"INFO","service":"pihole-docker","message":"Starting pihole-FTL as user pihole"}
pihole  | {"timestamp":"20260516T155606","log_level":"INFO","service":"pihole-docker","message":{"core":{"version":"9648b90","branch":"development","hash":"9648b901"},"web":{"version":"7e0949c","branch":"development","hash":"7e0949c2"},"ftl":{"version":"vDev-230eb78","branch":"development","hash":"230eb78e","date":"2026-05-16 12:31:13 +0200"}}}
pihole  | 2026-05-16 15:56:04.368 UTC [125M] INFO: ########## FTL started on 0b7a96562b8f! ##########
pihole  | 2026-05-16 15:56:04.368 UTC [125M] INFO: FTL branch: development
pihole  | 2026-05-16 15:56:04.368 UTC [125M] INFO: FTL version: vDev-230eb78
pihole  | 2026-05-16 15:56:04.368 UTC [125M] INFO: FTL commit: 230eb78e
[...]
pihole  | {"timestamp":"20260516T160218","log_level":"INFO","service":"pihole-docker","message":"Container stop requested..."}
pihole  | {"timestamp":"20260516T160218","log_level":"INFO","service":"pihole-docker","message":"pihole-FTL is running - Attempting to shut it down cleanly"}
pihole  | 
pihole  | 2026-05-16 16:02:18.433 UTC [125M] INFO: Shutting down (exit code 0, jmpret 0)
pihole  | 2026-05-16 16:02:18.443 UTC [125/T127] INFO: Terminating database thread
pihole  | 2026-05-16 16:02:18.479 UTC [125/T130] INFO: Terminating timer thread
pihole  | 2026-05-16 16:02:18.684 UTC [125M] INFO: Finished final database update
pihole  | 2026-05-16 16:02:18.684 UTC [125M] INFO: Asked to terminate by "N/A" (PID 343, user root UID 0)
pihole  | 2026-05-16 16:02:18.684 UTC [125M] INFO: Waiting for threads to join
pihole  | 2026-05-16 16:02:18.684 UTC [125M] INFO: Thread housekeeper (1) is idle, terminating it.
pihole  | 2026-05-16 16:02:18.684 UTC [125M] INFO: Thread dns-client (2) is idle, terminating it.
pihole  | 2026-05-16 16:02:18.684 UTC [125M] INFO: Thread ntp-client (4) is idle, terminating it.
pihole  | 2026-05-16 16:02:18.684 UTC [125M] INFO: Thread webserver (7) is idle, terminating it.
pihole  | 2026-05-16 16:02:18.684 UTC [125M] INFO: All threads joined
pihole  | 2026-05-16 16:02:18.685 UTC [125M] INFO: PID file emptied
pihole  | 2026-05-16 16:02:18.685 UTC [125M] INFO: Stored 0 API sessions in the database
pihole  | 2026-05-16 16:02:19.480 UTC [125M] INFO: Terminated by "N/A" (PID 343, user root UID 0)
pihole  | 2026-05-16 16:02:19.480 UTC [125M] INFO: ########## FTL terminated after 6m 15s  (code 0)! ##########
pihole  | {"timestamp":"20260516T160221","log_level":"INFO","service":"pihole-docker","message":"pihole-FTL exited with status 0"}
pihole  | {"timestamp":"20260516T160221","log_level":"INFO","service":"pihole-docker","message":"Container will now stop or restart depending on your restart policy - https://docs.docker.com/engine/containers/start-containers-automatically/#use-a-restart-policy"}

```
