### PR TITLE
feat: optimize Docker build caching

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -61,6 +61,7 @@ jobs:
       setup-qemu: true
       cache: true
       cache-scope: build
+      cache-mode: max
       fail-fast: true
       context: src
       output: image

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -20,7 +20,8 @@ ARG PIHOLE_GID=1000
 ENV DNSMASQ_USER=pihole
 ENV FTL_CMD=no-daemon
 
-RUN apk add --no-cache \
+RUN --mount=type=cache,target=/var/cache/apk \
+    apk add \
     bash \
     bash-completion \
     bind-tools \
@@ -43,21 +44,10 @@ RUN apk add --no-cache \
     unzip \
     wget
 
-# For nightly images, we install gdb and screen for ease of debugging (this is
-# not included in the default image to keep it small), and also prepare the
-# system for a core dump. Furthermore, we already add the required signal
-# instructions to the gdb config file
-RUN if [ "${PIHOLE_DOCKER_TAG}" = "nightly" ]; then \
-    apk add --no-cache gdb screen && \
-    echo "ulimit -c unlimited" >> /etc/profile && \
-    echo "handle SIGHUP nostop SIGPIPE nostop SIGTERM nostop SIG32 nostop SIG33 nostop SIG34 nostop SIG35 nostop SIG36 nostop SIG37 nostop SIG38 nostop SIG39 nostop SIG40 nostop SIG41 nostop" > /root/.gdbinit; \
-    fi
-
-ADD https://ftl.pi-hole.net/macvendor.db /macvendor.db
-COPY crontab.txt /crontab.txt
+ADD --link https://ftl.pi-hole.net/macvendor.db /macvendor.db
 
 # Add PADD to the container, too.
-ADD --chmod=0755 https://raw.githubusercontent.com/${PADD_FORK}/PADD/${PADD_BRANCH}/padd.sh /usr/local/bin/padd
+ADD --link --chmod=0755 https://raw.githubusercontent.com/${PADD_FORK}/PADD/${PADD_BRANCH}/padd.sh /usr/local/bin/padd
 
 # download a the main repos from github
 # if the branch is master we clone the latest tag as sometimes the master branch contains meta changes that have not been tagged
@@ -94,12 +84,23 @@ RUN cd /etc/.pihole && \
     install -Dm644 ./advanced/bash-completion/pihole-ftl.bash /etc/bash_completion.d/pihole-FTL && \
     install -T -m 0755 ./advanced/Templates/pihole-FTL-prestart.sh /opt/pihole/pihole-FTL-prestart.sh && \
     install -T -m 0755 ./advanced/Templates/pihole-FTL-poststop.sh /opt/pihole/pihole-FTL-poststop.sh && \
-    addgroup -S pihole -g ${PIHOLE_GID} && adduser -S pihole -G pihole -u ${PIHOLE_UID} && \
-    echo "${PIHOLE_DOCKER_TAG}" > /pihole.docker.tag
+    addgroup -S pihole -g ${PIHOLE_GID} && adduser -S pihole -G pihole -u ${PIHOLE_UID}
 
 COPY --chmod=0755 bash_functions.sh /usr/bin/bash_functions.sh
 COPY --chmod=0755 prefix-time.sh /usr/bin/prefix-time.sh
 COPY --chmod=0755 start.sh /usr/bin/start.sh
+COPY crontab.txt /crontab.txt
+
+# For nightly images, we install gdb and screen for ease of debugging (this is
+# not included in the default image to keep it small), and also prepare the
+# system for a core dump. Furthermore, we already add the required signal
+# instructions to the gdb config file
+RUN if [ "${PIHOLE_DOCKER_TAG}" = "nightly" ]; then \
+        apk add --no-cache gdb screen && \
+        echo "ulimit -c unlimited" >> /etc/profile && \
+        echo "handle SIGHUP nostop SIGPIPE nostop SIGTERM nostop SIG32 nostop SIG33 nostop SIG34 nostop SIG35 nostop SIG36 nostop SIG37 nostop SIG38 nostop SIG39 nostop SIG40 nostop SIG41 nostop" > /root/.gdbinit; \
+    fi; \
+    echo "${PIHOLE_DOCKER_TAG}" > /pihole.docker.tag
 
 EXPOSE 53 53/udp
 EXPOSE 67/udp


### PR DESCRIPTION
## Description
- Use a BuildKit cache mount (`--mount=type=cache,target=/var/cache/apk`) for `apk add` so downloaded packages are reused across builds instead of re-fetched every time
- Add `--link` flag to `ADD` instructions (macvendor.db, padd.sh) so Docker can reorder and restore those layers independently, improving cache reuse
- Enable `cache-mode: max` in the CI workflow to maximize the number of layers saved to the cache
- Reorder Dockerfile layers to place volatile steps (nightly debug tools, crontab copy, docker tag file) after the stable install layers, so a nightly-only change doesn't bust the cache for normal builds

## Motivation and Context
Allowing individual layers to be cached between builds means smaller quicker image pulls between versions. For example, if there is no PADD change, then that layer can get reused between releases.

## How Has This Been Tested?

For testing, I ran the pipeline twice. The [first run](https://github.com/pi-hole/docker-pi-hole/actions/runs/26350566933/attempts/1?pr=2038), had a 0% cache hit - due to the changes:

<img width="1040" height="310" alt="image" src="https://github.com/user-attachments/assets/331e98b3-4be2-4302-b2f0-5ab73740af89" />

On the [second run](https://github.com/pi-hole/docker-pi-hole/actions/runs/26350566933?pr=2038), it hit 52%:

<img width="1084" height="328" alt="image" src="https://github.com/user-attachments/assets/b956b54f-621d-4685-9afb-0a724457574c" />

I was expecting more cache reuse than that. I think there is more opportunities with reorganizing the Dockerfile to make more use build stages - but I don't want to blow up the PR with a bunch of changes that are hard to review.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.