### PR TITLE
remove buildkit cache mount from apk add layer

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -20,8 +20,7 @@ ARG PIHOLE_GID=1000
 ENV DNSMASQ_USER=pihole
 ENV FTL_CMD=no-daemon
 
-RUN --mount=type=cache,target=/var/cache/apk \
-    apk add \
+RUN apk add \
     bash \
     bash-completion \
     bind-tools \


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

A BuildKit cache mount (--mount=type=cache,target=/var/cache/apk) was used on the main apk add layer to speed up repeated local builds. However, this created a security risk: even when the Alpine base image digest changed (e.g. via a Dependabot bump), the BuildKit runner cache continued serving stale .apk files from disk rather than fetching updated packages from the Alpine repos.

This was observed when bind-libs 9.20.22-r0 remained installed despite 9.20.23-r0 being available in the Alpine package repositories.

Two caching layers compounded this issue:

GHA Docker layer cache (cache-mode: max) — caches the entire RUN apk add layer; only invalidated when the Dockerfile content or base image digest changes.
BuildKit APK cache mount — persists downloaded .apk files on the runner between builds; served stale packages even when the layer did re-run after a base image bump.

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_