### PR TITLE
Restore --no-cache flag for apk

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -20,7 +20,7 @@ ARG PIHOLE_GID=1000
 ENV DNSMASQ_USER=pihole
 ENV FTL_CMD=no-daemon
 
-RUN apk add \
+RUN apk add --no-cache \
     bash \
     bash-completion \
     bind-tools \


### PR DESCRIPTION
## Description

The `--no-cache` flag was removed in https://github.com/pi-hole/docker-pi-hole/pull/2038 but not added back in https://github.com/pi-hole/docker-pi-hole/pull/2049
