### PR TITLE
Allow to stream webserver.log to docker output

### DIFF
--- a/src/start.sh
+++ b/src/start.sh
@@ -55,12 +55,14 @@ start() {
     fix_capabilities
     sh /opt/pihole/pihole-FTL-prestart.sh
 
-    # Get the FTL log file path from the config
+    # Get the FTL and web server log file path from the config
     FTLlogFile=$(getFTLConfigValue files.log.ftl)
+    WEBlogFile=$(getFTLConfigValue files.log.webserver)
 
-    # Get the EOF position of the FTL log file so that we can tail from there later.
-    local startFrom
-    startFrom=$(stat -c%s "${FTLlogFile}")
+    # Get the EOF position of the FTL and web server log file so that we can tail from there later.
+    local FTLstartFrom WEBstartFrom
+    FTLstartFrom=$(stat -c%s "${FTLlogFile}")
+    WEBstartFrom=$(stat -c%s "${WEBlogFile}")
 
     echo "  [i] Starting pihole-FTL ($FTL_CMD) as ${DNSMASQ_USER}"
     echo ""
@@ -75,7 +77,7 @@ start() {
     CAPSH_PID=$!
 
     # Wait for FTL to start by monitoring the FTL log file for the "FTL started" line
-    if ! timeout 30 tail -F -c +$((startFrom + 1)) -- "${FTLlogFile}" | grep -q '########## FTL started'; then
+    if ! timeout 30 tail -F -c +$((FTLstartFrom + 1)) -- "${FTLlogFile}" | grep -q '########## FTL started'; then
         echo "  [!] ERROR: Did not find 'FTL started' message in ${FTLlogFile} in 30 seconds, stopping container"
         exit 1
     fi
@@ -89,10 +91,19 @@ start() {
 
     if [ "${TAIL_FTL_LOG:-1}" -eq 1 ]; then
         # Start tailing the FTL log file from the EOF position we recorded on container start
-        tail -F -c +$((startFrom + 1)) -- "${FTLlogFile}" &
+        tail -F -c +$((FTLstartFrom + 1)) -- "${FTLlogFile}" &
     else
         echo "  [i] FTL log output is disabled. Remove the Environment variable TAIL_FTL_LOG, or set it to 1 to enable FTL log output."
     fi
+    if [ "${TAIL_WEB_LOG:-1}" -eq 1 ]; then
+        # Start tailing the web server log file from the EOF position we recorded on container start
+        tail -F -c +$((WEBstartFrom + 1)) -- "${WEBlogFile}" &
+    else
+        echo "  [i] Web server log output is disabled. Remove the Environment variable TAIL_WEB_LOG, or set it to 1 to enable web server log output."
+    fi
+
+
+
 
     # Wait for the capsh process (which spawned FTL) to finish
     wait $CAPSH_PID

--- a/test/test_default.bats
+++ b/test/test_default.bats
@@ -39,6 +39,14 @@ teardown_file() {
     assert_success
 }
 
+# ---- Web log is tailed to docker log ------------------------------------------------
+
+@test "Web server log is tailed to docker log" {
+    run docker logs "$CONTAINER"
+    assert_success
+    assert_output --partial "Initializing HTTP server on ports"
+}
+
 # ---- Web password setup -----------------------------------------------------
 
 @test "Random password is assigned on fresh start" {

--- a/test/test_env_vars.bats
+++ b/test/test_env_vars.bats
@@ -12,7 +12,8 @@ setup_file() {
         -e FTLCONF_webserver_port=8080 \
         -e FTLCONF_dns_upstreams="8.8.8.8;1.1.1.1" \
         -e ADDITIONAL_PACKAGES=wget \
-        -e TAIL_FTL_LOG=0)
+        -e TAIL_FTL_LOG=0 \
+        -e TAIL_WEB_LOG=0)
     wait_for_log "$CONTAINER" "FTL log output is disabled"
     export CONTAINER
 }
@@ -75,4 +76,15 @@ teardown_file() {
     assert_success
     assert_output --partial "FTL log output is disabled"
     refute_output --partial "########## FTL started"
+}
+
+# ---- TAIL_WEB_LOG disabled --------------------------------------------------
+
+@test "TAIL_WEB_LOG=0 suppresses web server log output in docker logs" {
+    # TAIL_WEB_LOG defaults to 1 (enabled); the default container exercises that path.
+    # This test verifies the opt-out case.
+    run docker logs "$CONTAINER"
+    assert_success
+    assert_output --partial "Web server log output is disabled"
+    refute_output --partial "Initializing HTTP server on ports"
 }


### PR DESCRIPTION
Idea inspired by https://github.com/pi-hole/FTL/pull/2958.
This would allow to stream the output of `webserver.log` to the docker log. Currently it's not very useful as the `webserver.log` output is sparse and uses a different format than FTL.log. But I see potential if more things get moved from FTL.log into webserver.log plus `json` logging.

Logging is controlled by env `TAIL_WEB_LOG` which defaults to `true`.

____

```
pihole  | 2026-07-27 09:50:22.837 UTC [55M] INFO:    [✓] FTLCONF_webserver_api_password is used
pihole  | 2026-07-27 09:50:22.837 UTC [55M] INFO: Wrote config file:
pihole  | [2026-07-27 09:50:22.866 UTC 55] Initializing HTTP server on ports "80o,443os,[::]:80o,[::]:443os"
pihole  | 2026-07-27 09:50:22.837 UTC [55M] INFO:  - 169 total entries
pihole  | 2026-07-27 09:50:22.837 UTC [55M] INFO:  - 164 entries are default
pihole  | 2026-07-27 09:50:22.837 UTC [55M] INFO:  - 5 entries are modified
```

