### PR TITLE
Document the ports for encrypted DNS and HTTP/3

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ services:
       #- "67:67/udp"
       # Uncomment the line below if you are using Pi-hole as your NTP server
       #- "123:123/udp"
+      # Uncomment the lines below if your clients should use Pi-hole as an encrypted
+      # resolver: DNS-over-TLS (TCP) and DNS-over-QUIC (UDP). DNS-over-HTTPS needs no
+      # port of its own, it is served on the HTTPS port above
+      #- "853:853/tcp"
+      #- "853:853/udp"
+      # Uncomment the line below for HTTP/3, which runs on UDP on the same port
+      # number and carries both the web interface and DoH. Without it, clients
+      # simply stay on HTTP/2
+      #- "443:443/udp"
     environment:
       # Set the appropriate timezone for your location (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), e.g:
       TZ: 'Europe/London'
@@ -93,6 +102,7 @@ services:
 For more detailed information, please refer to our documentation:
 
 - [Running DHCP from Docker Pi-Hole](https://docs.pi-hole.net/docker/DHCP/)
+- [Encrypted DNS for your clients (DoT, DoH, DoQ)](https://docs.pi-hole.net/ftldns/encrypted-dns/)
 - [Configuration](https://docs.pi-hole.net/docker/configuration/)
 - [Tips and Tricks](https://docs.pi-hole.net/docker/tips-and-tricks/)
 - [Docker tags and versioning](https://docs.pi-hole.net/docker/#docker-tags-and-versioning)

--- a/examples/docker-compose-encrypted-dns.yml
+++ b/examples/docker-compose-encrypted-dns.yml
@@ -1,0 +1,43 @@
+# Pi-hole as an encrypted resolver for your clients.
+#
+# FTL answers DNS-over-TLS (DoT), DNS-over-QUIC (DoQ) and DNS-over-HTTPS (DoH)
+# itself, so no proxy in front of the container is needed. All three are enabled
+# by default and use the same certificate as the web interface.
+#
+# More info at https://docs.pi-hole.net/ftldns/encrypted-dns/
+services:
+  pihole:
+    container_name: pihole
+    image: pihole/pihole:latest
+    ports:
+      # Plain DNS
+      - "53:53/tcp"
+      - "53:53/udp"
+      # Web interface and API. The HTTPS port also serves DoH at /dns-query, and
+      # HTTP/3 on the same port number over UDP
+      - "80:80/tcp"
+      - "443:443/tcp"
+      - "443:443/udp"
+      # DoT (TCP) and DoQ (UDP). Both use port 853, they do not collide.
+      # These are published on every host address - prefix them with your LAN
+      # address (e.g. "192.168.1.2:853:853/tcp") if the host also faces the
+      # Internet, so you do not run an open resolver
+      - "853:853/tcp"
+      - "853:853/udp"
+    environment:
+      TZ: 'Europe/London'
+      FTLCONF_webserver_api_password: 'correct horse battery staple'
+      # If using Docker's default `bridge` network setting the dns listening mode should be set to 'ALL'
+      FTLCONF_dns_listeningMode: 'ALL'
+      # The listeners are on by default. Set a port to move DoT/DoQ, or 0 to switch
+      # them off - we recommend staying on 853, as that is the port clients try
+      # first. DoH is a plain on/off switch, as it rides on the HTTPS port
+      #FTLCONF_dns_dot: '853'
+      #FTLCONF_dns_doq: '853'
+      #FTLCONF_dns_doh: 'true'
+      # Clients validate the certificate against the name they connect to. Set this
+      # to the name your clients use, so the generated certificate matches it
+      #FTLCONF_webserver_domain: 'pi.hole'
+    volumes:
+      - './etc-pihole:/etc/pihole'
+    restart: unless-stopped

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -105,7 +105,8 @@ EXPOSE 53 53/udp
 EXPOSE 67/udp
 EXPOSE 80
 EXPOSE 123/udp
-EXPOSE 443
+EXPOSE 443 443/udp
+EXPOSE 853 853/udp
 
 ## Buildkit can do some fancy stuff and we can use it to either download FTL from ftl.pi-hole.net or use a local copy
 


### PR DESCRIPTION
## Description

Adds the ports that Pi-hole v7 needs when clients use it as an encrypted resolver - DNS-over-TLS on TCP `853` and DNS-over-QUIC on UDP `853` - and the UDP port for HTTP/3 on the web interface. DNS-over-HTTPS gets no port of its own, it is served at `/dns-query` on the HTTPS port, which is noted in the comments.

Also adds `examples/docker-compose-encrypted-dns.yml` and links the new documentation page in the README.

## Motivation and Context

FTL answers DoT/DoH/DoQ itself since pi-hole/FTL#2989 and pi-hole/FTL#3000, with configurable listener ports in pi-hole/FTL#3012, so a container can offer encrypted DNS to the clients in your network without a proxy in front of it - but only if the ports are published. Documentation counterpart: pi-hole/docs#1416.

This is a **draft** to be merged **with the release of v7.0**: the README and the example describe features that have not shipped yet.

## How Has This Been Tested?

Not runtime-tested - this changes comments, an example file and a documentation link only. The example was checked to be valid YAML, and the repository's `editorconfig-checker` and `codespell` both pass.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
