### PR TITLE
fix: fail closed on FTL and GitHub release downloads

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -59,7 +59,11 @@ RUN clone_repo() { \
         DEST="$4"; \
         CLONE_BRANCH="$BRANCH"; \
         if [ "$BRANCH" = "master" ]; then \
-            CLONE_BRANCH=$(curl -s https://api.github.com/repos/${FORK}/${REPO}/releases/latest | jq -r .tag_name); \
+            CLONE_BRANCH=$(curl -fsSL "https://api.github.com/repos/${FORK}/${REPO}/releases/latest" | jq -r .tag_name); \
+            if [ -z "$CLONE_BRANCH" ] || [ "$CLONE_BRANCH" = "null" ]; then \
+                echo "Failed to resolve latest release tag for ${FORK}/${REPO}"; \
+                exit 1; \
+            fi; \
         fi; \
         git clone --branch "$CLONE_BRANCH" --single-branch --depth 1 "https://github.com/${FORK}/${REPO}.git" "$DEST"; \
         cd "$DEST"; \
@@ -122,7 +126,7 @@ RUN if   [ "$TARGETPLATFORM" = "linux/amd64" ];    then FTLARCH=amd64; \
     else FTLARCH=amd64; fi \
     && echo "Arch: ${TARGETPLATFORM}, FTLARCH: ${FTLARCH}" \
     && if [ "${FTL_BRANCH}" = "master" ]; then URL="https://github.com/pi-hole/ftl/releases/latest/download"; else URL="https://ftl.pi-hole.net/${FTL_BRANCH}"; fi \
-    && curl -sSL "${URL}/pihole-FTL-${FTLARCH}" -o /usr/bin/pihole-FTL \
+    && curl -fsSL "${URL}/pihole-FTL-${FTLARCH}" -o /usr/bin/pihole-FTL \
     && chmod +x /usr/bin/pihole-FTL \
     && readelf -h /usr/bin/pihole-FTL || (echo "Error with downloaded FTL binary" && exit 1) \
     && /usr/bin/pihole-FTL  -vv


### PR DESCRIPTION
## Summary

`curl` without `--fail` could write an HTTP error body as `pihole-FTL`, or leave `CLONE_BRANCH` as `null` when the GitHub API is rate-limited, producing a broken image.

Require a successful download (`curl -fsSL`) and a real release tag before cloning.

## Test plan

- [x] Extracted `clone_repo` from the Dockerfile and `bash -n` it
- [x] Confirmed FTL download uses `curl -fsSL`
- [x] Confirmed null/empty tag names abort the build
- Full image build / BATS suite was not run here (no Docker daemon)